### PR TITLE
fix: write output in `py::cli`

### DIFF
--- a/src/py.rs
+++ b/src/py.rs
@@ -18,9 +18,10 @@ pub fn cli(args: &Bound<PyTuple>) -> PyResult<()> {
         .chain(args.extract::<Vec<OsString>>()?)
         .collect_vec();
     let context = inkwell::context::Context::create();
-    Cli::try_parse_from(args)
-        .map_err(anyhow::Error::from)?
-        .run(&context)?;
+    let mut cli = Cli::try_parse_from(args)
+        .map_err(anyhow::Error::from)?;
+    let module = cli.run(&context)?;
+    cli.write_module(&module)?;
     Ok(())
 }
 


### PR DESCRIPTION
Tested with `pytest --basetemp _x && cat _x/test_guppy_planqc_qcurrent/out.ll` 