### PR TITLE
feat: Make `pyo3` an optional (but default) feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,9 +95,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.95"
+version = "1.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
+checksum = "6b964d184e89d9b6b67dd2715bc8e74cf3107fb2b529990c90cf517326150bf4"
 
 [[package]]
 name = "approx"
@@ -147,7 +147,7 @@ dependencies = [
  "duplicate",
  "itertools 0.12.1",
  "lazy_static",
- "petgraph",
+ "petgraph 0.6.5",
  "proc-macro2",
  "quote",
  "syn",
@@ -270,9 +270,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.26"
+version = "4.5.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8eb5e908ef3a6efbe1ed62520fb7287959888c88485abe072543190ecc66783"
+checksum = "92b7b18d71fad5313a1e320fa9897994228ce274b60faa4d694fe0ea89cd9e6d"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -290,9 +290,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.26"
+version = "4.5.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96b01801b5fc6a0a232407abc821660c9c6d25a1cafc0d4f85f29fb8d9afc121"
+checksum = "a35db2071778a7344791a4fb4f95308b5673d219dee3ae348b86642574ecc90c"
 dependencies = [
  "anstream",
  "anstyle",
@@ -302,9 +302,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.24"
+version = "4.5.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54b755194d6389280185988721fffba69495eed5ee9feeee9a599b53db80318c"
+checksum = "bf4ced95c6f4a675af3da73304b9ac4ed991640c36374e4b46795c49e17cf1ed"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -350,12 +350,6 @@ dependencies = [
  "once_cell",
  "windows-sys 0.59.0",
 ]
-
-[[package]]
-name = "context-iterators"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07ec5b69614ae4dbce88efe2684f4526e3a5aeb0a68326d1424f69c98f3040d2"
 
 [[package]]
 name = "core-foundation-sys"
@@ -453,9 +447,9 @@ dependencies = [
 
 [[package]]
 name = "delegate"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc2323e10c92e1cf4d86e11538512e6dc03ceb586842970b6332af3d4046a046"
+checksum = "297806318ef30ad066b15792a8372858020ae3ca2e414ee6c2133b1eb9e9e945"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -506,9 +500,9 @@ dependencies = [
 
 [[package]]
 name = "downcast-rs"
-version = "1.2.1"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+checksum = "ea8a8b81cacc08888170eef4d13b775126db426d0b348bee9d18c2c1eaf123cf"
 
 [[package]]
 name = "duplicate"
@@ -579,58 +573,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
-name = "futures"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-executor",
- "futures-io",
- "futures-sink",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
-name = "futures-channel"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
-dependencies = [
- "futures-core",
- "futures-sink",
-]
-
-[[package]]
 name = "futures-core"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
-
-[[package]]
-name = "futures-executor"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
-dependencies = [
- "futures-core",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
-name = "futures-io"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-macro"
@@ -642,12 +600,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "futures-sink"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
 
 [[package]]
 name = "futures-task"
@@ -667,13 +619,9 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
- "futures-channel",
  "futures-core",
- "futures-io",
  "futures-macro",
- "futures-sink",
  "futures-task",
- "memchr",
  "pin-project-lite",
  "pin-utils",
  "slab",
@@ -755,9 +703,9 @@ dependencies = [
 
 [[package]]
 name = "hugr"
-version = "0.14.1"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1c8f4a7f778b70a6528fb620f9df31931d9eaad518287d7d25faabba8714f3f"
+checksum = "65e8fb919d87dd5b9c1ba077a289c765b6e184c832768fb4a5dc9e1e05793564"
 dependencies = [
  "hugr-core",
  "hugr-llvm",
@@ -766,9 +714,9 @@ dependencies = [
 
 [[package]]
 name = "hugr-cli"
-version = "0.14.1"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5906f571c65f74ec9f7aac92d1d52bf1a1837d736d4bd131d3d81b13c057068"
+checksum = "207ce216fc76a3f2e56bb27483502468d6b8758e6c7a8a777cdf8d64459043cf"
 dependencies = [
  "clap",
  "clap-verbosity-flag",
@@ -780,9 +728,9 @@ dependencies = [
 
 [[package]]
 name = "hugr-core"
-version = "0.14.1"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "967ce11e97050617c536d37c5b12d2b0eecb2f9f6da24e4bc5d19faf5cf1fafa"
+checksum = "79da6020b18a6c63bd81acb9b86370820ba63062519b9d10ed75a0561f3143d1"
 dependencies = [
  "bitvec",
  "bumpalo",
@@ -794,11 +742,11 @@ dependencies = [
  "fxhash",
  "html-escape",
  "indexmap",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "lazy_static",
  "num-rational",
  "paste",
- "petgraph",
+ "petgraph 0.7.1",
  "portgraph",
  "regex",
  "semver",
@@ -813,21 +761,22 @@ dependencies = [
 
 [[package]]
 name = "hugr-llvm"
-version = "0.14.1"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "152a4914fb30b6284321848dbcedb47dc8f2a9ac4d0b3af01092b85e73f409b8"
+checksum = "cad14a387b0a8e9164cb503a49f74fe36959a776af28bdf2d4da634651e2a19d"
 dependencies = [
  "anyhow",
  "delegate",
+ "derive_more",
  "hugr-core",
  "inkwell",
  "insta",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "lazy_static",
  "pathsearch",
- "petgraph",
+ "petgraph 0.7.1",
  "portgraph",
- "rstest 0.23.0",
+ "rstest",
  "serde",
  "serde_json",
  "strum",
@@ -836,16 +785,16 @@ dependencies = [
 
 [[package]]
 name = "hugr-passes"
-version = "0.14.1"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a12944d441477c4f086c106891fa22e5a29ac2fd011c0caf898e4d28aeb2a05"
+checksum = "86dff9354c0133cddd4f9060af2f4ec531dc479c1a65ed5474785f5b39478422"
 dependencies = [
  "ascent",
  "hugr-core",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "lazy_static",
  "paste",
- "petgraph",
+ "petgraph 0.7.1",
  "portgraph",
  "thiserror 2.0.10",
 ]
@@ -866,7 +815,7 @@ dependencies = [
  "itertools 0.14.0",
  "lazy_static",
  "pyo3",
- "rstest 0.24.0",
+ "rstest",
  "serde",
  "serde_json",
  "tket2",
@@ -899,9 +848,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.7.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f"
+checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.2",
@@ -940,13 +889,14 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "1.42.0"
+version = "1.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6513e4067e16e69ed1db5ab56048ed65db32d10ba5fc1217f5393f8f17d8b5a5"
+checksum = "71c1b125e30d93896b365e156c33dadfffab45ee8400afcbba4752f59de08a86"
 dependencies = [
  "console",
  "linked-hash-map",
  "once_cell",
+ "pin-project",
  "similar",
 ]
 
@@ -990,15 +940,6 @@ name = "itertools"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -1231,8 +1172,38 @@ version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
- "fixedbitset",
+ "fixedbitset 0.4.2",
  "indexmap",
+]
+
+[[package]]
+name = "petgraph"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
+dependencies = [
+ "fixedbitset 0.5.7",
+ "indexmap",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfe2e71e1471fe07709406bf725f710b02927c9c54b2b5b2ec0e8087d97c327d"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6e859e6e5bd50440ab63c47e3ebabc90f26251f7c73c3d3e837b74a1cc3fa67"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1261,24 +1232,23 @@ checksum = "280dc24453071f1b63954171985a0b0d30058d287960968b9b2aca264c8d4ee6"
 
 [[package]]
 name = "portgraph"
-version = "0.12.3"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bfec2c00343ab6227cb3da08a1c9bed2d79fc379d040ce98582e81e825f96d1"
+checksum = "66fcb76974f489d449dce2409cd132171194e3c75b67f69ecfa533ac761b77b3"
 dependencies = [
  "bitvec",
- "context-iterators",
  "delegate",
- "itertools 0.13.0",
- "petgraph",
+ "itertools 0.14.0",
+ "petgraph 0.7.1",
  "serde",
  "thiserror 2.0.10",
 ]
 
 [[package]]
 name = "priority-queue"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714c75db297bc88a63783ffc6ab9f830698a6705aa0201416931759ef4c8183d"
+checksum = "090ded312ed32a928fb49cb91ab4db6523ae3767225e61fbf6ceaaec3664ed26"
 dependencies = [
  "autocfg",
  "equivalent",
@@ -1305,9 +1275,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.22.6"
+version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f402062616ab18202ae8319da13fa4279883a2b8a9d9f83f20dbade813ce1884"
+checksum = "57fe09249128b3173d092de9523eaa75136bf7ba85e0d69eca241c7939c933cc"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -1324,9 +1294,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.22.6"
+version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b14b5775b5ff446dd1056212d778012cbe8a0fbffd368029fd9e25b514479c38"
+checksum = "1cd3927b5a78757a0d71aa9dff669f903b1eb64b54142a9bd9f757f8fde65fd7"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -1334,9 +1304,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.22.6"
+version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ab5bcf04a2cdcbb50c7d6105de943f543f9ed92af55818fd17b660390fc8636"
+checksum = "dab6bb2102bd8f991e7749f130a70d05dd557613e39ed2deeee8e9ca0c4d548d"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -1344,9 +1314,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.22.6"
+version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fd24d897903a9e6d80b968368a34e1525aeb719d568dba8b3d4bfa5dc67d453"
+checksum = "91871864b353fd5ffcb3f91f2f703a22a9797c91b9ab497b1acac7b07ae509c7"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -1356,9 +1326,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.22.6"
+version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36c011a03ba1e50152b4b394b479826cad97e7a21eb52df179cd91ac411cbfbe"
+checksum = "43abc3b80bc20f3facd86cd3c60beed58c3e2aa26213f3cda368de39c60a27e4"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -1448,44 +1418,14 @@ checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 
 [[package]]
 name = "rstest"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a2c585be59b6b5dd66a9d2084aa1d8bd52fbdb806eafdeffb52791147862035"
-dependencies = [
- "futures",
- "futures-timer",
- "rstest_macros 0.23.0",
- "rustc_version",
-]
-
-[[package]]
-name = "rstest"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03e905296805ab93e13c1ec3a03f4b6c4f35e9498a3d5fa96dc626d22c03cd89"
 dependencies = [
  "futures-timer",
  "futures-util",
- "rstest_macros 0.24.0",
+ "rstest_macros",
  "rustc_version",
-]
-
-[[package]]
-name = "rstest_macros"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "825ea780781b15345a146be27eaefb05085e337e869bff01b4306a4fd4a9ad5a"
-dependencies = [
- "cfg-if",
- "glob",
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "regex",
- "relative-path",
- "rustc_version",
- "syn",
- "unicode-ident",
 ]
 
 [[package]]
@@ -1572,18 +1512,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.217"
+version = "1.0.218"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
+checksum = "e8dfc9d19bdbf6d17e22319da49161d5d0108e4188e8b680aef6299eed22df60"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.217"
+version = "1.0.218"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
+checksum = "f09503e191f4e797cb8aac08e9a4a4695c5edf6a2e70e376d961ddd5c969f82b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1592,9 +1532,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.135"
+version = "1.0.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b0d7ba2887406110130a978386c4e1befb98c674b4fba677954e4db976630d9"
+checksum = "44f86c3acccc9c65b153fe1b85a3be07fe5515274ec9f0653b4a0875731c72a6"
 dependencies = [
  "itoa",
  "memchr",
@@ -1770,9 +1710,9 @@ dependencies = [
 
 [[package]]
 name = "tket2"
-version = "0.7.0"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40278c34ec1d09fc156bbfd1ced33baacaab0cab0419c4e8e182376b104f6324"
+checksum = "26090aba0185f6328395d491bc577c333e844f3d997d811793eb6384be4dfd16"
 dependencies = [
  "bytemuck",
  "cgmath",
@@ -1786,12 +1726,12 @@ dependencies = [
  "hugr",
  "hugr-core",
  "indexmap",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "lazy_static",
  "num-rational",
  "pest",
  "pest_derive",
- "petgraph",
+ "petgraph 0.7.1",
  "portgraph",
  "priority-queue",
  "rayon",
@@ -1808,15 +1748,16 @@ dependencies = [
 
 [[package]]
 name = "tket2-hseries"
-version = "0.7.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd0108a909642a7dddb185c12108bf9a68add253e702713c058217c3c0e0710"
+checksum = "0956f811ff070cd50129d417d832eee5f051854aa135b0afa0832f3f2061e3fc"
 dependencies = [
  "clap",
+ "delegate",
  "derive_more",
  "hugr",
  "hugr-cli",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "lazy_static",
  "serde",
  "serde_json",
@@ -1824,6 +1765,7 @@ dependencies = [
  "strum",
  "strum_macros",
  "tket2",
+ "typetag",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,10 @@ name = "hugr-qir"
 version = "0.0.1"
 edition = "2021"
 
+[features]
+default = ["py"]
+py = ["dep:pyo3"]
+
 [dependencies]
 anyhow = "1.0.95"
 clap = "4.5.26"
@@ -14,10 +18,13 @@ hugr-cli = "0.14.1"
 hugr-llvm = { version = "0.14.1", features = ["test-utils"] }
 itertools = "0.14.0"
 lazy_static = "1.5.0"
-pyo3 = { version = "0.22.6", features = ["abi3-py310", "anyhow"] }
+pyo3 = { version = "0.22.6", features = [
+    "abi3-py310",
+    "anyhow",
+], optional = true }
 serde_json = "1.0.135"
 tket2 = "0.7.0"
-tket2-hseries = {  version = "0.7.1", features = ["cli"] }
+tket2-hseries = { version = "0.7.1", features = ["cli"] }
 
 [dev-dependencies]
 insta = "1.42.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,26 +8,26 @@ default = ["py"]
 py = ["dep:pyo3"]
 
 [dependencies]
-anyhow = "1.0.95"
-clap = "4.5.26"
+anyhow = "1.0.96"
+clap = "4.5.30"
 clap-verbosity-flag = "3.0.2"
 clio = { version = "0.3.5", features = ["clap-parse"] }
-delegate = "0.13.1"
-hugr = { version = "0.14.1", features = ["llvm"] }
-hugr-cli = "0.14.1"
-hugr-llvm = { version = "0.14.1", features = ["test-utils"] }
+delegate = "0.13.2"
+hugr = { version = "0.14.3", features = ["llvm"] }
+hugr-cli = "0.14.3"
+hugr-llvm = { version = "0.14.3", features = ["test-utils"] }
 itertools = "0.14.0"
 lazy_static = "1.5.0"
-pyo3 = { version = "0.22.6", features = [
+pyo3 = { version = "0.23.4", features = [
     "abi3-py310",
     "anyhow",
 ], optional = true }
-serde_json = "1.0.135"
-tket2 = "0.7.0"
-tket2-hseries = { version = "0.7.1", features = ["cli"] }
+serde_json = "1.0.139"
+tket2 = "0.7.2"
+tket2-hseries = { version = "0.9.0", features = ["cli"] }
 
 [dev-dependencies]
-insta = "1.42.0"
+insta = "1.42.1"
 rstest = "0.24.0"
-serde = { version = "1.0.217", features = ["derive"] }
+serde = { version = "1.0.218", features = ["derive"] }
 typetag = "0.2.19"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,8 +15,10 @@ use qir::{QirCodegenExtension, QirPreludeCodegen};
 use rotation::RotationCodegenExtension;
 
 pub mod cli;
-mod py;
 pub mod qir;
+
+#[cfg(feature = "py")]
+mod py;
 
 // TODO this was copy pasted, ideally it would live in tket2-hseries
 pub mod rotation;

--- a/src/qir/qsystem_ext.rs
+++ b/src/qir/qsystem_ext.rs
@@ -92,7 +92,7 @@ impl QirCodegenExtension {
             QSystemOp::TryQAlloc => {
                 let qb = emit_qis_qalloc(context)?;
                 let option_ty = context.llvm_sum_type(option_type(qb_t()))?;
-                let qb = option_ty.build_tag(context.builder(), 1, vec![qb])?;
+                let qb = option_ty.build_tag(context.builder(), 1, vec![qb])?.into();
                 args.outputs.finish(context.builder(), [qb])
             }
             QSystemOp::QFree => emit_qis_qfree(context, args.inputs[0]),
@@ -152,7 +152,7 @@ mod test {
         insta.set_snapshot_suffix(format!(
             "{}_{}",
             insta.snapshot_suffix().unwrap_or(""),
-            op.name()
+            NamedOp::name(&op)
         ));
         insta.bind(|| {
             let hugr = single_op_hugr(op);

--- a/uv.lock
+++ b/uv.lock
@@ -1,4 +1,5 @@
 version = 1
+revision = 1
 requires-python = ">=3.10"
 
 [[package]]
@@ -71,7 +72,6 @@ wheels = [
 
 [[package]]
 name = "hugr-qir"
-version = "0.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "guppylang" },


### PR DESCRIPTION
I'm using the codegen definitions from here in the experimental [`guppyc`](https://github.com/CQCL/guppyc) / [`hugr-explorer`](https://github.com/CQCL/hugr-explorer) and I'd _really_ want to avoid having `pyo3` in my dependency tree.

This PR adds an enabled-by-default `py` feature to selectively disable the python bindings, and the `pyo3` cargo dependency.

drive-by: Update `hugr-*` dependencies.