### PR TITLE
feat: Add hugr validation to python cli

### DIFF
--- a/python/hugr_qir/hugr_to_qir.py
+++ b/python/hugr_qir/hugr_to_qir.py
@@ -12,12 +12,18 @@ from .cli import hugr_qir_impl
 
 
 def hugr_to_qir(
-    hugr: ModulePointer | bytes, *, validate_qir: bool = True, emit_text: bool = False
+    hugr: ModulePointer | bytes,
+    *,
+    validate_qir: bool = True,
+    validate_hugr: bool = False,
+    emit_text: bool = False,
 ) -> str:
     """A function for converting hugr to qir (llvm bitcode)
 
     :param hugr: HUGR in binary format
     :param validate_qir: Whether to validate the created QIR
+    :param validate_hugr: Whether to validate the input hugr before
+     and after each internal pass
     :param emit_text: If True, output qir as human-readable LLVM assembly language
 
     :returns: QIR corresponding to the HUGR input as an LLVM bitcode string base64
@@ -39,7 +45,9 @@ def hugr_to_qir(
         with Path.open(Path(temp_infile.name), "wb") as cli_input:
             cli_input.write(hugr_bytes)
         with Path.open(Path(temp_outfile.name), "w") as cli_output:
-            hugr_qir_impl(validate_qir, Path(temp_infile.name), cli_output)
+            hugr_qir_impl(
+                validate_qir, validate_hugr, Path(temp_infile.name), cli_output
+            )
         with Path.open(Path(temp_outfile.name), "r") as cli_output:
             qir_ir = cli_output.read()
             if emit_text:

--- a/python/tests/test_guppy_examples.py
+++ b/python/tests/test_guppy_examples.py
@@ -17,7 +17,12 @@ guppy_files_xpass = list(guppy_files)
 )
 def test_guppy_files(tmp_path: Path, guppy_file: Path) -> None:
     out_file = tmp_path / "out.ll"
-    cli_on_guppy(guppy_file, tmp_path, "-o", str(out_file))
+    cli_on_guppy(
+        guppy_file,
+        tmp_path,
+        "-o",
+        str(out_file),
+    )
 
 
 @pytest.mark.parametrize(
@@ -28,7 +33,14 @@ def test_guppy_file_snapshots(
 ) -> None:
     snapshot.snapshot_dir = SNAPSHOT_DIR
     out_file = tmp_path / "out.ll"
-    cli_on_guppy(guppy_file, tmp_path, "-o", str(out_file), "--no-validate-qir")
+    cli_on_guppy(
+        guppy_file,
+        tmp_path,
+        "-o",
+        str(out_file),
+        "--no-validate-qir",
+        "--validate-hugr",
+    )
     with Path.open(out_file) as f:
         qir = f.read()
     snapshot.assert_match(qir, str(Path(guppy_file.stem).with_suffix(".ll")))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,6 +72,9 @@ impl CompileArgs {
 
     /// TODO: Change to "hugr: &mut impl HugrMut" once QSeriesPass works on &mut impl HugrMut
     pub fn hugr_to_hugr(&self, hugr: &mut Hugr) -> Result<()> {
+        if self.validate {
+            hugr.validate()?;
+        }
         if self.qsystem_pass {
             let pass = tket2_hseries::QSystemPass::default();
             pass.run(hugr)?;


### PR DESCRIPTION
- Added the option of turning on hugr validation before and after each pass
- Added validation before first pass
- Turned on validation for the snapshot guppy example tests (the rust tests mentioned in the issue were moved to python)

fixes #44 