### PR TITLE
use llvm default optimisation pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Changelog
 
-### v0.0.6
+### v0.0.7
 
 - expose option to validate input hugr
 - update guppylang version requirement 0.20.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -975,6 +975,7 @@ dependencies = [
  "hugr-cli",
  "hugr-core",
  "hugr-llvm",
+ "inkwell",
  "insta",
  "itertools 0.14.0",
  "lazy_static",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -162,9 +162,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "base64"
@@ -217,9 +217,9 @@ checksum = "38c99613cb3cd7429889a08dfcf651721ca971c86afa30798461f8eee994de47"
 
 [[package]]
 name = "bumpalo"
-version = "3.18.1"
+version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db76d6187cd04dff33004d8e6c9cc4e05cd330500379d2394209271b4aeee"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "bytemuck"
@@ -244,9 +244,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.26"
+version = "1.2.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "956a5e21988b87f372569b66183b78babf23ebc2e744b733e4350a752c4dafac"
+checksum = "4ad45f4f74e4e20eaa392913b7b33a7091c87e59628f4dd27888205ad888843c"
 dependencies = [
  "jobserver",
  "libc",
@@ -543,9 +543,9 @@ dependencies = [
 
 [[package]]
 name = "derive-where"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e73f2692d4bd3cac41dca28934a39894200c9fabf49586d77d0e5954af1d7902"
+checksum = "510c292c8cf384b1a340b816a9a6cf2599eb8f566a44949024af88418000c50b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -609,6 +609,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97af9b5f014e228b33e77d75ee0e6e87960124f0f4b16337b586a6bec91867b1"
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c7a8fb8a9fbf66c1f703fe16184d10ca0ee9d23be5b4436400408ba54a95005"
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -656,12 +662,12 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
+checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -816,9 +822,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f154ce46856750ed433c8649605bf7ed2de3bc35fd9d2a9f30cddd873c80cb08"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -837,9 +843,9 @@ dependencies = [
 
 [[package]]
 name = "hugr"
-version = "0.20.1"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be90c2e1f9aba85bab9d5a0e7979a53fda07005fb7ace398df07be786d58e6ef"
+checksum = "462367504afb43961a4afe3a2fff746fef80f9f2f1ec2faecf245a562ab1d7ab"
 dependencies = [
  "hugr-core",
  "hugr-llvm",
@@ -849,23 +855,25 @@ dependencies = [
 
 [[package]]
 name = "hugr-cli"
-version = "0.20.1"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e6630cead0c1b5b34be3b8b42f828256bee4843818205edd4f7d8cb0f149d2c"
+checksum = "1e7dd7d2eb5d95bbd8a64ff6c8c26b72074701698e0b8e83a3ad2c35d335ab52"
 dependencies = [
+ "anyhow",
  "clap",
  "clap-verbosity-flag",
  "clio",
  "derive_more 1.0.0",
  "hugr",
  "serde_json",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
 name = "hugr-core"
-version = "0.20.1"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ed7f33e2c45ebccb95496ec609143f8d6a25ecfb6da60535df1d55eb88ecbf9"
+checksum = "545209fd52be8f4af29b08595f6a065565aa16dd26b1e83f8af1058688353e5f"
 dependencies = [
  "cgmath",
  "delegate",
@@ -875,7 +883,7 @@ dependencies = [
  "fxhash",
  "html-escape",
  "hugr-model",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "itertools 0.14.0",
  "lazy_static",
  "paste",
@@ -897,9 +905,9 @@ dependencies = [
 
 [[package]]
 name = "hugr-llvm"
-version = "0.20.1"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "424a3d73d558377f4cee0ce3320334d10b265c5357997730253e53b888620e7f"
+checksum = "94eb49c2cc4ae3f7d54c8c6f2c0a331465325eb89745385663538dccfca54d59"
 dependencies = [
  "anyhow",
  "delegate",
@@ -917,16 +925,16 @@ dependencies = [
 
 [[package]]
 name = "hugr-model"
-version = "0.20.1"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97d27208d4076ea6f437c3dcf9d1466a9d6a1d7938a1296c4ebc3ccb76482bf1"
+checksum = "e13917825a242ef816337ce1a7939dd95589122b154f3c3e5f6b15e6025c109a"
 dependencies = [
  "base64",
  "bumpalo",
  "capnp",
  "derive_more 1.0.0",
  "fxhash",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "itertools 0.14.0",
  "ordered-float",
  "pest",
@@ -938,9 +946,9 @@ dependencies = [
 
 [[package]]
 name = "hugr-passes"
-version = "0.20.1"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d141482c92df56834938b7e2bdd0b4a1bc48019e71a430ca6a65339775d5c4"
+checksum = "812103e60642aeabbd37b1e1fcf4c5cb595e9a0a2123a7d03c02b48e3216a848"
 dependencies = [
  "ascent",
  "derive_more 1.0.0",
@@ -956,7 +964,7 @@ dependencies = [
 
 [[package]]
 name = "hugr-qir"
-version = "0.0.6"
+version = "0.0.7"
 dependencies = [
  "anyhow",
  "clap",
@@ -1023,9 +1031,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.4",
@@ -1161,9 +1169,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.172"
+version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1202,9 +1210,9 @@ checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "memchr"
-version = "2.7.4"
+version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
 name = "memoffset"
@@ -1261,7 +1269,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1321,7 +1329,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset 0.4.2",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
 ]
 
 [[package]]
@@ -1332,7 +1340,7 @@ checksum = "54acf3a685220b533e437e264e4d932cfbdc4cc7ec0cd232ed73c08d03b8a7ca"
 dependencies = [
  "fixedbitset 0.5.7",
  "hashbrown 0.15.4",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "serde",
 ]
 
@@ -1399,7 +1407,7 @@ checksum = "5676d703dda103cbb035b653a9f11448c0a7216c7926bd35fcb5865475d0c970"
 dependencies = [
  "autocfg",
  "equivalent",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
 ]
 
 [[package]]
@@ -1495,9 +1503,9 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
-version = "5.2.0"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "radium"
@@ -1527,11 +1535,31 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.12"
+version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
+checksum = "0d04b7d0ee6b4a0207a0a7adb104d23ecb0b47d6beae7152d0fa34b692b29fd6"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a0ae411dbe946a674d89546582cea4ba2bb8defac896622d6496f14c23ba5cf"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1165225c21bff1f3bbce98f5a1f889949bc902d3575308cc7b0de30b4f6d27c7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1580,6 +1608,7 @@ dependencies = [
  "fxhash",
  "itertools 0.13.0",
  "petgraph 0.8.2",
+ "serde",
  "thiserror 1.0.69",
 ]
 
@@ -1693,6 +1722,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1375ba8ef45a6f15d83fa8748f1079428295d403d6ea991d09ab100155fbc06d"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1741,15 +1794,17 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.12.0"
+version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6b6f7f2fcb69f747921f79f3926bd1e203fce4fef62c268dd3abfb6d86029aa"
+checksum = "f2c45cd61fefa9db6f254525d46e392b852e0e61d9a1fd36e5bd183450a556d5"
 dependencies = [
  "base64",
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
+ "schemars 0.9.0",
+ "schemars 1.0.3",
  "serde",
  "serde_derive",
  "serde_json",
@@ -1759,9 +1814,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.12.0"
+version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d00caa5193a3c8362ac2b73be6b9e768aa5a4b2f721d8f4b339600c3cb51f8e"
+checksum = "de90945e6565ce0d9a25098082ed4ee4002e047cb59892c318d66821e14bb30f"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -1794,12 +1849,9 @@ checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "slab"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
-dependencies = [
- "autocfg",
-]
+checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
 
 [[package]]
 name = "smallvec"
@@ -1853,9 +1905,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.102"
+version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6397daf94fa90f058bd0fd88429dd9e5738999cca8d701813c80723add80462"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1973,9 +2025,9 @@ dependencies = [
 
 [[package]]
 name = "tket2"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b496dc44c7eaca6a8c8eac9618e1559ccb28b1018dcc59b0a95ded82a5a524e"
+checksum = "bb2520be9aff4e51f1a31298e8cccd61dcf54a344b70cbc907fbae0bc9ce83ca"
 dependencies = [
  "bytemuck",
  "cgmath",
@@ -1987,7 +2039,7 @@ dependencies = [
  "fxhash",
  "hugr",
  "hugr-core",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "itertools 0.14.0",
  "lazy_static",
  "pest",
@@ -2018,7 +2070,7 @@ dependencies = [
  "derive_more 1.0.0",
  "hugr",
  "hugr-cli",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "itertools 0.14.0",
  "lazy_static",
  "serde",
@@ -2040,7 +2092,7 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "toml_datetime",
  "winnow",
 ]
@@ -2058,9 +2110,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.29"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b1ffbcf9c6f6b99d386e7444eb608ba646ae452a36b39737deb9663b610f662"
+checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2301,9 +2353,9 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
-version = "0.1.1"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
 name = "windows-result"
@@ -2344,7 +2396,16 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.2",
 ]
 
 [[package]]
@@ -2356,11 +2417,27 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c66f69fcc9ce11da9966ddb31a40968cad001c5bedeb5c2b82ede4253ab48aef"
+dependencies = [
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
 ]
 
 [[package]]
@@ -2376,6 +2453,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2386,6 +2469,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2400,10 +2489,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -2418,6 +2519,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2428,6 +2535,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -2442,6 +2555,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2454,10 +2573,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "winnow"
-version = "0.7.10"
+name = "windows_x86_64_msvc"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06928c8748d81b05c9be96aad92e1b6ff01833332f281e8cfca3be4b35fc9ec"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+
+[[package]]
+name = "winnow"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74c7b26e3480b707944fc872477815d29a8e429d2f93a1ce000f5fa84a15cbcd"
 dependencies = [
  "memchr",
 ]
@@ -2482,18 +2607,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.25"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
+checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.25"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
+checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ py = ["dep:pyo3"]
 [dependencies]
 anyhow = "1.0.98"
 clap = "4.5.39"
+inkwell = { version = "0.6.0", features = ["llvm14-0"] }
 clap-verbosity-flag = "3.0.2"
 clio = { version = "0.3.5", features = ["clap-parse"] }
 delegate = "0.13.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hugr-qir"
-version = "0.0.6"
+version = "0.0.7"
 edition = "2024"
 rust-version = "1.85"
 

--- a/hello.py
+++ b/hello.py
@@ -1,6 +1,0 @@
-def main() -> None:
-    print("Hello from hugr-qir!")
-
-
-if __name__ == "__main__":
-    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hugr-qir"
-version = "0.0.6"
+version = "0.0.7"
 description = "Quantinuum's tool for converting HUGR to QIR"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/python/tests/snapshots/planqc-1.ll
+++ b/python/tests/snapshots/planqc-1.ll
@@ -1,33 +1,35 @@
 ; ModuleID = 'hugr-qir'
 source_filename = "hugr-qir"
+target datalayout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128"
+target triple = "aarch64-unknown-linux-gnu"
 
 %Qubit = type opaque
 %Result = type opaque
 
 @0 = private unnamed_addr constant [2 x i8] c"1\00", align 1
 
-define void @__hugr__.main.1() #0 {
+define void @__hugr__.main.1() local_unnamed_addr #0 {
 alloca_block:
-  call void @__quantum__qis__phasedx__body(double 0x3FF921FB54442D18, double 0xBFF921FB54442D18, %Qubit* null)
-  call void @__quantum__qis__rz__body(double 0x400921FB54442D18, %Qubit* null)
-  call void @__quantum__qis__rz__body(double 0x4012D97C7F3321D2, %Qubit* null)
-  call void @__quantum__qis__phasedx__body(double 0x3FF921FB54442D18, double 0xBFF921FB54442D18, %Qubit* null)
-  call void @__quantum__qis__rz__body(double 0x400921FB54442D18, %Qubit* null)
-  call void @__quantum__qis__mz__body(%Qubit* null, %Result* null)
-  %0 = call i1 @__quantum__qis__read_result__body(%Result* null)
-  call void @__quantum__rt__bool_record_output(i1 %0, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  tail call void @__quantum__qis__phasedx__body(double 0x3FF921FB54442D18, double 0xBFF921FB54442D18, %Qubit* null)
+  tail call void @__quantum__qis__rz__body(double 0x400921FB54442D18, %Qubit* null)
+  tail call void @__quantum__qis__rz__body(double 0x4012D97C7F3321D2, %Qubit* null)
+  tail call void @__quantum__qis__phasedx__body(double 0x3FF921FB54442D18, double 0xBFF921FB54442D18, %Qubit* null)
+  tail call void @__quantum__qis__rz__body(double 0x400921FB54442D18, %Qubit* null)
+  tail call void @__quantum__qis__mz__body(%Qubit* null, %Result* null)
+  %0 = tail call i1 @__quantum__qis__read_result__body(%Result* null)
+  tail call void @__quantum__rt__bool_record_output(i1 %0, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i64 0, i64 0))
   ret void
 }
 
-declare void @__quantum__qis__phasedx__body(double, double, %Qubit*)
+declare void @__quantum__qis__phasedx__body(double, double, %Qubit*) local_unnamed_addr
 
-declare void @__quantum__qis__rz__body(double, %Qubit*)
+declare void @__quantum__qis__rz__body(double, %Qubit*) local_unnamed_addr
 
-declare void @__quantum__qis__mz__body(%Qubit*, %Result*)
+declare void @__quantum__qis__mz__body(%Qubit*, %Result*) local_unnamed_addr
 
-declare i1 @__quantum__qis__read_result__body(%Result*)
+declare i1 @__quantum__qis__read_result__body(%Result*) local_unnamed_addr
 
-declare void @__quantum__rt__bool_record_output(i1, i8*)
+declare void @__quantum__rt__bool_record_output(i1, i8*) local_unnamed_addr
 
 attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="custom" "required_num_qubits"="1" "required_num_results"="1" }
 

--- a/python/tests/snapshots/quantum-classical-1.ll
+++ b/python/tests/snapshots/quantum-classical-1.ll
@@ -1,35 +1,37 @@
 ; ModuleID = 'hugr-qir'
 source_filename = "hugr-qir"
+target datalayout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128"
+target triple = "aarch64-unknown-linux-gnu"
 
 %Qubit = type opaque
 %Result = type opaque
 
 @0 = private unnamed_addr constant [2 x i8] c"0\00", align 1
 
-define void @__hugr__.main.1() #0 {
+define void @__hugr__.main.1() local_unnamed_addr #0 {
 alloca_block:
-  call void @__quantum__qis__phasedx__body(double 0x3FF921FB54442D18, double 0xBFF921FB54442D18, %Qubit* null)
-  call void @__quantum__qis__rz__body(double 0x400921FB54442D18, %Qubit* null)
-  call void @__quantum__qis__mz__body(%Qubit* null, %Result* null)
-  %0 = call i1 @__quantum__qis__read_result__body(%Result* null)
-  call void @__quantum__qis__phasedx__body(double 0x3FF921FB54442D18, double 0xBFF921FB54442D18, %Qubit* inttoptr (i64 1 to %Qubit*))
-  call void @__quantum__qis__rz__body(double 0x400921FB54442D18, %Qubit* inttoptr (i64 1 to %Qubit*))
-  call void @__quantum__qis__mz__body(%Qubit* inttoptr (i64 1 to %Qubit*), %Result* inttoptr (i64 1 to %Result*))
-  %1 = call i1 @__quantum__qis__read_result__body(%Result* inttoptr (i64 1 to %Result*))
+  tail call void @__quantum__qis__phasedx__body(double 0x3FF921FB54442D18, double 0xBFF921FB54442D18, %Qubit* null)
+  tail call void @__quantum__qis__rz__body(double 0x400921FB54442D18, %Qubit* null)
+  tail call void @__quantum__qis__mz__body(%Qubit* null, %Result* null)
+  %0 = tail call i1 @__quantum__qis__read_result__body(%Result* null)
+  tail call void @__quantum__qis__phasedx__body(double 0x3FF921FB54442D18, double 0xBFF921FB54442D18, %Qubit* nonnull inttoptr (i64 1 to %Qubit*))
+  tail call void @__quantum__qis__rz__body(double 0x400921FB54442D18, %Qubit* nonnull inttoptr (i64 1 to %Qubit*))
+  tail call void @__quantum__qis__mz__body(%Qubit* nonnull inttoptr (i64 1 to %Qubit*), %Result* nonnull inttoptr (i64 1 to %Result*))
+  %1 = tail call i1 @__quantum__qis__read_result__body(%Result* nonnull inttoptr (i64 1 to %Result*))
   %2 = xor i1 %0, %1
-  call void @__quantum__rt__bool_record_output(i1 %2, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  tail call void @__quantum__rt__bool_record_output(i1 %2, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i64 0, i64 0))
   ret void
 }
 
-declare void @__quantum__qis__phasedx__body(double, double, %Qubit*)
+declare void @__quantum__qis__phasedx__body(double, double, %Qubit*) local_unnamed_addr
 
-declare void @__quantum__qis__rz__body(double, %Qubit*)
+declare void @__quantum__qis__rz__body(double, %Qubit*) local_unnamed_addr
 
-declare void @__quantum__qis__mz__body(%Qubit*, %Result*)
+declare void @__quantum__qis__mz__body(%Qubit*, %Result*) local_unnamed_addr
 
-declare i1 @__quantum__qis__read_result__body(%Result*)
+declare i1 @__quantum__qis__read_result__body(%Result*) local_unnamed_addr
 
-declare void @__quantum__rt__bool_record_output(i1, i8*)
+declare void @__quantum__rt__bool_record_output(i1, i8*) local_unnamed_addr
 
 attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="custom" "required_num_qubits"="2" "required_num_results"="2" }
 

--- a/python/tests/snapshots/quantum-complex-1.ll
+++ b/python/tests/snapshots/quantum-complex-1.ll
@@ -1,5 +1,7 @@
 ; ModuleID = 'hugr-qir'
 source_filename = "hugr-qir"
+target datalayout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128"
+target triple = "aarch64-unknown-linux-gnu"
 
 %Qubit = type opaque
 %Result = type opaque
@@ -7,48 +9,48 @@ source_filename = "hugr-qir"
 @0 = private unnamed_addr constant [2 x i8] c"0\00", align 1
 @1 = private unnamed_addr constant [2 x i8] c"1\00", align 1
 
-define void @__hugr__.main.1() #0 {
+define void @__hugr__.main.1() local_unnamed_addr #0 {
 alloca_block:
-  call void @__quantum__qis__phasedx__body(double 0x3FF921FB54442D18, double 0xBFF921FB54442D18, %Qubit* null)
-  call void @__quantum__qis__rz__body(double 0x400921FB54442D18, %Qubit* null)
-  call void @__quantum__qis__rz__body(double 0x3FF921FB54442D18, %Qubit* null)
-  call void @__quantum__qis__rz__body(double 0x3FE921FB54442D18, %Qubit* null)
-  call void @__quantum__qis__phasedx__body(double 0x400921FB54442D18, double 0.000000e+00, %Qubit* null)
-  call void @__quantum__qis__phasedx__body(double 0x400921FB54442D18, double 0x3FF921FB54442D18, %Qubit* null)
-  call void @__quantum__qis__rz__body(double 0x400921FB54442D18, %Qubit* null)
-  call void @__quantum__qis__phasedx__body(double 0xBFF921FB54442D18, double 0x3FF921FB54442D18, %Qubit* inttoptr (i64 1 to %Qubit*))
-  call void @__quantum__qis__rzz__body(double 0x3FF921FB54442D18, %Qubit* null, %Qubit* inttoptr (i64 1 to %Qubit*))
-  call void @__quantum__qis__rz__body(double 0xBFF921FB54442D18, %Qubit* null)
-  call void @__quantum__qis__phasedx__body(double 0x3FF921FB54442D18, double 0x400921FB54442D18, %Qubit* inttoptr (i64 1 to %Qubit*))
-  call void @__quantum__qis__rz__body(double 0xBFF921FB54442D18, %Qubit* inttoptr (i64 1 to %Qubit*))
-  call void @__quantum__qis__phasedx__body(double 0x400921FB54442D18, double 0x3FF921FB54442D18, %Qubit* null)
-  call void @__quantum__qis__rzz__body(double 0x3FF921FB54442D18, %Qubit* null, %Qubit* inttoptr (i64 1 to %Qubit*))
-  call void @__quantum__qis__rz__body(double 0x3FF921FB54442D18, %Qubit* inttoptr (i64 1 to %Qubit*))
-  call void @__quantum__qis__phasedx__body(double 0x400921FB54442D18, double 0xBFF921FB54442D18, %Qubit* null)
-  call void @__quantum__qis__rz__body(double 0x3FF921FB54442D18, %Qubit* null)
-  call void @__quantum__qis__phasedx__body(double 0x4012D97C7F3321D2, double 0.000000e+00, %Qubit* null)
-  call void @__quantum__qis__phasedx__body(double 0x4012D97C7F3321D2, double 0x3FF921FB54442D18, %Qubit* null)
-  call void @__quantum__qis__rz__body(double 0x4012D97C7F3321D2, %Qubit* null)
-  call void @__quantum__qis__mz__body(%Qubit* null, %Result* null)
-  %0 = call i1 @__quantum__qis__read_result__body(%Result* null)
-  call void @__quantum__rt__bool_record_output(i1 %0, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
-  call void @__quantum__qis__mz__body(%Qubit* inttoptr (i64 1 to %Qubit*), %Result* inttoptr (i64 1 to %Result*))
-  %1 = call i1 @__quantum__qis__read_result__body(%Result* inttoptr (i64 1 to %Result*))
-  call void @__quantum__rt__bool_record_output(i1 %1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @1, i32 0, i32 0))
+  tail call void @__quantum__qis__phasedx__body(double 0x3FF921FB54442D18, double 0xBFF921FB54442D18, %Qubit* null)
+  tail call void @__quantum__qis__rz__body(double 0x400921FB54442D18, %Qubit* null)
+  tail call void @__quantum__qis__rz__body(double 0x3FF921FB54442D18, %Qubit* null)
+  tail call void @__quantum__qis__rz__body(double 0x3FE921FB54442D18, %Qubit* null)
+  tail call void @__quantum__qis__phasedx__body(double 0x400921FB54442D18, double 0.000000e+00, %Qubit* null)
+  tail call void @__quantum__qis__phasedx__body(double 0x400921FB54442D18, double 0x3FF921FB54442D18, %Qubit* null)
+  tail call void @__quantum__qis__rz__body(double 0x400921FB54442D18, %Qubit* null)
+  tail call void @__quantum__qis__phasedx__body(double 0xBFF921FB54442D18, double 0x3FF921FB54442D18, %Qubit* nonnull inttoptr (i64 1 to %Qubit*))
+  tail call void @__quantum__qis__rzz__body(double 0x3FF921FB54442D18, %Qubit* null, %Qubit* nonnull inttoptr (i64 1 to %Qubit*))
+  tail call void @__quantum__qis__rz__body(double 0xBFF921FB54442D18, %Qubit* null)
+  tail call void @__quantum__qis__phasedx__body(double 0x3FF921FB54442D18, double 0x400921FB54442D18, %Qubit* nonnull inttoptr (i64 1 to %Qubit*))
+  tail call void @__quantum__qis__rz__body(double 0xBFF921FB54442D18, %Qubit* nonnull inttoptr (i64 1 to %Qubit*))
+  tail call void @__quantum__qis__phasedx__body(double 0x400921FB54442D18, double 0x3FF921FB54442D18, %Qubit* null)
+  tail call void @__quantum__qis__rzz__body(double 0x3FF921FB54442D18, %Qubit* null, %Qubit* nonnull inttoptr (i64 1 to %Qubit*))
+  tail call void @__quantum__qis__rz__body(double 0x3FF921FB54442D18, %Qubit* nonnull inttoptr (i64 1 to %Qubit*))
+  tail call void @__quantum__qis__phasedx__body(double 0x400921FB54442D18, double 0xBFF921FB54442D18, %Qubit* null)
+  tail call void @__quantum__qis__rz__body(double 0x3FF921FB54442D18, %Qubit* null)
+  tail call void @__quantum__qis__phasedx__body(double 0x4012D97C7F3321D2, double 0.000000e+00, %Qubit* null)
+  tail call void @__quantum__qis__phasedx__body(double 0x4012D97C7F3321D2, double 0x3FF921FB54442D18, %Qubit* null)
+  tail call void @__quantum__qis__rz__body(double 0x4012D97C7F3321D2, %Qubit* null)
+  tail call void @__quantum__qis__mz__body(%Qubit* null, %Result* null)
+  %0 = tail call i1 @__quantum__qis__read_result__body(%Result* null)
+  tail call void @__quantum__rt__bool_record_output(i1 %0, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i64 0, i64 0))
+  tail call void @__quantum__qis__mz__body(%Qubit* nonnull inttoptr (i64 1 to %Qubit*), %Result* nonnull inttoptr (i64 1 to %Result*))
+  %1 = tail call i1 @__quantum__qis__read_result__body(%Result* nonnull inttoptr (i64 1 to %Result*))
+  tail call void @__quantum__rt__bool_record_output(i1 %1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @1, i64 0, i64 0))
   ret void
 }
 
-declare void @__quantum__qis__phasedx__body(double, double, %Qubit*)
+declare void @__quantum__qis__phasedx__body(double, double, %Qubit*) local_unnamed_addr
 
-declare void @__quantum__qis__rz__body(double, %Qubit*)
+declare void @__quantum__qis__rz__body(double, %Qubit*) local_unnamed_addr
 
-declare void @__quantum__qis__rzz__body(double, %Qubit*, %Qubit*)
+declare void @__quantum__qis__rzz__body(double, %Qubit*, %Qubit*) local_unnamed_addr
 
-declare void @__quantum__qis__mz__body(%Qubit*, %Result*)
+declare void @__quantum__qis__mz__body(%Qubit*, %Result*) local_unnamed_addr
 
-declare i1 @__quantum__qis__read_result__body(%Result*)
+declare i1 @__quantum__qis__read_result__body(%Result*) local_unnamed_addr
 
-declare void @__quantum__rt__bool_record_output(i1, i8*)
+declare void @__quantum__rt__bool_record_output(i1, i8*) local_unnamed_addr
 
 attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="custom" "required_num_qubits"="2" "required_num_results"="2" }
 

--- a/python/tests/snapshots/quantum-conditional-1.ll
+++ b/python/tests/snapshots/quantum-conditional-1.ll
@@ -1,46 +1,48 @@
 ; ModuleID = 'hugr-qir'
 source_filename = "hugr-qir"
+target datalayout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128"
+target triple = "aarch64-unknown-linux-gnu"
 
 %Qubit = type opaque
 %Result = type opaque
 
 @0 = private unnamed_addr constant [2 x i8] c"0\00", align 1
 
-define void @__hugr__.main.1() #0 {
+define void @__hugr__.main.1() local_unnamed_addr #0 {
 alloca_block:
-  call void @__quantum__qis__phasedx__body(double 0x3FF921FB54442D18, double 0xBFF921FB54442D18, %Qubit* null)
-  call void @__quantum__qis__rz__body(double 0x400921FB54442D18, %Qubit* null)
-  call void @__quantum__qis__phasedx__body(double 0xBFF921FB54442D18, double 0x3FF921FB54442D18, %Qubit* inttoptr (i64 1 to %Qubit*))
-  call void @__quantum__qis__rzz__body(double 0x3FF921FB54442D18, %Qubit* null, %Qubit* inttoptr (i64 1 to %Qubit*))
-  call void @__quantum__qis__rz__body(double 0xBFF921FB54442D18, %Qubit* null)
-  call void @__quantum__qis__phasedx__body(double 0x3FF921FB54442D18, double 0x400921FB54442D18, %Qubit* inttoptr (i64 1 to %Qubit*))
-  call void @__quantum__qis__rz__body(double 0xBFF921FB54442D18, %Qubit* inttoptr (i64 1 to %Qubit*))
-  call void @__quantum__qis__mz__body(%Qubit* null, %Result* inttoptr (i64 1 to %Result*))
-  %0 = call i1 @__quantum__qis__read_result__body(%Result* inttoptr (i64 1 to %Result*))
-  br i1 %0, label %2, label %cond_exit_109
+  tail call void @__quantum__qis__phasedx__body(double 0x3FF921FB54442D18, double 0xBFF921FB54442D18, %Qubit* null)
+  tail call void @__quantum__qis__rz__body(double 0x400921FB54442D18, %Qubit* null)
+  tail call void @__quantum__qis__phasedx__body(double 0xBFF921FB54442D18, double 0x3FF921FB54442D18, %Qubit* nonnull inttoptr (i64 1 to %Qubit*))
+  tail call void @__quantum__qis__rzz__body(double 0x3FF921FB54442D18, %Qubit* null, %Qubit* nonnull inttoptr (i64 1 to %Qubit*))
+  tail call void @__quantum__qis__rz__body(double 0xBFF921FB54442D18, %Qubit* null)
+  tail call void @__quantum__qis__phasedx__body(double 0x3FF921FB54442D18, double 0x400921FB54442D18, %Qubit* nonnull inttoptr (i64 1 to %Qubit*))
+  tail call void @__quantum__qis__rz__body(double 0xBFF921FB54442D18, %Qubit* nonnull inttoptr (i64 1 to %Qubit*))
+  tail call void @__quantum__qis__mz__body(%Qubit* null, %Result* nonnull inttoptr (i64 1 to %Result*))
+  %0 = tail call i1 @__quantum__qis__read_result__body(%Result* nonnull inttoptr (i64 1 to %Result*))
+  br i1 %0, label %2, label %cond_109_case_1
 
-cond_exit_109:                                    ; preds = %alloca_block, %2
-  call void @__quantum__qis__mz__body(%Qubit* inttoptr (i64 1 to %Qubit*), %Result* null)
-  %1 = call i1 @__quantum__qis__read_result__body(%Result* null)
-  call void @__quantum__rt__bool_record_output(i1 %1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+cond_109_case_1:                                  ; preds = %alloca_block, %2
+  tail call void @__quantum__qis__mz__body(%Qubit* nonnull inttoptr (i64 1 to %Qubit*), %Result* null)
+  %1 = tail call i1 @__quantum__qis__read_result__body(%Result* null)
+  tail call void @__quantum__rt__bool_record_output(i1 %1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i64 0, i64 0))
   ret void
 
 2:                                                ; preds = %alloca_block
-  call void @__quantum__qis__phasedx__body(double 0x400921FB54442D18, double 0.000000e+00, %Qubit* inttoptr (i64 1 to %Qubit*))
-  br label %cond_exit_109
+  tail call void @__quantum__qis__phasedx__body(double 0x400921FB54442D18, double 0.000000e+00, %Qubit* nonnull inttoptr (i64 1 to %Qubit*))
+  br label %cond_109_case_1
 }
 
-declare void @__quantum__qis__phasedx__body(double, double, %Qubit*)
+declare void @__quantum__qis__phasedx__body(double, double, %Qubit*) local_unnamed_addr
 
-declare void @__quantum__qis__rz__body(double, %Qubit*)
+declare void @__quantum__qis__rz__body(double, %Qubit*) local_unnamed_addr
 
-declare void @__quantum__qis__rzz__body(double, %Qubit*, %Qubit*)
+declare void @__quantum__qis__rzz__body(double, %Qubit*, %Qubit*) local_unnamed_addr
 
-declare void @__quantum__qis__mz__body(%Qubit*, %Result*)
+declare void @__quantum__qis__mz__body(%Qubit*, %Result*) local_unnamed_addr
 
-declare i1 @__quantum__qis__read_result__body(%Result*)
+declare i1 @__quantum__qis__read_result__body(%Result*) local_unnamed_addr
 
-declare void @__quantum__rt__bool_record_output(i1, i8*)
+declare void @__quantum__rt__bool_record_output(i1, i8*) local_unnamed_addr
 
 attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="custom" "required_num_qubits"="2" "required_num_results"="2" }
 

--- a/python/tests/snapshots/quantum-conditional-2.ll
+++ b/python/tests/snapshots/quantum-conditional-2.ll
@@ -1,5 +1,7 @@
 ; ModuleID = 'hugr-qir'
 source_filename = "hugr-qir"
+target datalayout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128"
+target triple = "aarch64-unknown-linux-gnu"
 
 %Qubit = type opaque
 %Result = type opaque
@@ -7,80 +9,42 @@ source_filename = "hugr-qir"
 @0 = private unnamed_addr constant [2 x i8] c"a\00", align 1
 @1 = private unnamed_addr constant [2 x i8] c"b\00", align 1
 
-define void @__hugr__.main.1() #0 {
+define void @__hugr__.main.1() local_unnamed_addr #0 {
 alloca_block:
-  call void @__quantum__qis__phasedx__body(double 0x3FF921FB54442D18, double 0xBFF921FB54442D18, %Qubit* null)
-  call void @__quantum__qis__rz__body(double 0x400921FB54442D18, %Qubit* null)
-  call void @__quantum__qis__mz__body(%Qubit* null, %Result* inttoptr (i64 2 to %Result*))
-  %0 = call i1 @__quantum__qis__read_result__body(%Result* inttoptr (i64 2 to %Result*))
-  %1 = insertvalue { i1, i1 } { i1 true, i1 poison }, i1 %0, 1
-  %2 = extractvalue { i1, i1 } %1, 0
-  %3 = insertvalue { i1, i1 } { i1 false, i1 poison }, i1 %0, 1
-  %4 = insertvalue { i1, i1 } { i1 false, i1 poison }, i1 %0, 1
-  %5 = insertvalue { i1, i1 } { i1 true, i1 poison }, i1 %0, 1
-  %6 = insertvalue { i1, i1 } { i1 true, i1 poison }, i1 %0, 1
-  %"039.0" = select i1 %2, { i1, i1 } %6, { i1, i1 } %4
-  %"1.0" = select i1 %2, { i1, i1 } %5, { i1, i1 } %3
-  %7 = extractvalue { i1, i1 } %"039.0", 0
-  %8 = extractvalue { i1, i1 } %"039.0", 1
-  %9 = extractvalue { i1, i1 } %"039.0", 1
-  %"060.0" = select i1 %7, i1 %9, i1 %8
-  br i1 %"060.0", label %cond_exit_65, label %10
+  tail call void @__quantum__qis__phasedx__body(double 0x3FF921FB54442D18, double 0xBFF921FB54442D18, %Qubit* null)
+  tail call void @__quantum__qis__rz__body(double 0x400921FB54442D18, %Qubit* null)
+  tail call void @__quantum__qis__mz__body(%Qubit* null, %Result* nonnull inttoptr (i64 2 to %Result*))
+  %0 = tail call i1 @__quantum__qis__read_result__body(%Result* nonnull inttoptr (i64 2 to %Result*))
+  br i1 %0, label %cond_65_case_1, label %1
 
-cond_exit_178:                                    ; preds = %cond_exit_65, %10
-  %"55_1.0.reg2mem.sroa.3.0.reg2mem.0" = phi i1 [ %"51_1.0.reload.fca.1.extract", %cond_exit_65 ], [ %11, %10 ]
-  %"55_0.0.reg2mem.sroa.3.0.reg2mem.0" = phi i1 [ %"51_0.0.reload.fca.1.extract", %cond_exit_65 ], [ %"1.0.reload.fca.1.extract", %10 ]
-  call void @__quantum__rt__bool_record_output(i1 %"55_0.0.reg2mem.sroa.3.0.reg2mem.0", i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
-  call void @__quantum__rt__bool_record_output(i1 %"55_1.0.reg2mem.sroa.3.0.reg2mem.0", i8* getelementptr inbounds ([2 x i8], [2 x i8]* @1, i32 0, i32 0))
+cond_exit_178:                                    ; preds = %cond_65_case_1, %1
+  %"55_1.sroa.5.0" = phi i1 [ false, %cond_65_case_1 ], [ %2, %1 ]
+  tail call void @__quantum__rt__bool_record_output(i1 %0, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i64 0, i64 0))
+  tail call void @__quantum__rt__bool_record_output(i1 %"55_1.sroa.5.0", i8* getelementptr inbounds ([2 x i8], [2 x i8]* @1, i64 0, i64 0))
   ret void
 
-10:                                               ; preds = %alloca_block
-  call void @__quantum__qis__mz__body(%Qubit* inttoptr (i64 1 to %Qubit*), %Result* inttoptr (i64 1 to %Result*))
-  %11 = call i1 @__quantum__qis__read_result__body(%Result* inttoptr (i64 1 to %Result*))
-  %"1.0.reload.fca.1.extract" = extractvalue { i1, i1 } %"1.0", 1
+1:                                                ; preds = %alloca_block
+  tail call void @__quantum__qis__mz__body(%Qubit* nonnull inttoptr (i64 1 to %Qubit*), %Result* nonnull inttoptr (i64 1 to %Result*))
+  %2 = tail call i1 @__quantum__qis__read_result__body(%Result* nonnull inttoptr (i64 1 to %Result*))
   br label %cond_exit_178
 
-cond_exit_65:                                     ; preds = %alloca_block
-  call void @__quantum__qis__phasedx__body(double 0x3FF921FB54442D18, double 0xBFF921FB54442D18, %Qubit* inttoptr (i64 1 to %Qubit*))
-  call void @__quantum__qis__rz__body(double 0x400921FB54442D18, %Qubit* inttoptr (i64 1 to %Qubit*))
-  call void @__quantum__qis__mz__body(%Qubit* inttoptr (i64 1 to %Qubit*), %Result* null)
-  %12 = call i1 @__quantum__qis__read_result__body(%Result* null)
-  %13 = insertvalue { i1, i1 } { i1 true, i1 poison }, i1 %12, 1
-  %14 = extractvalue { i1, i1 } %13, 0
-  %15 = insertvalue { i1, i1 } { i1 false, i1 poison }, i1 %12, 1
-  %16 = insertvalue { i1, i1 } { i1 false, i1 poison }, i1 %12, 1
-  %17 = insertvalue { i1, i1 } { i1 true, i1 poison }, i1 %12, 1
-  %18 = insertvalue { i1, i1 } { i1 true, i1 poison }, i1 %12, 1
-  %"090.0" = select i1 %14, { i1, i1 } %18, { i1, i1 } %16
-  %"191.0" = select i1 %14, { i1, i1 } %17, { i1, i1 } %15
-  %19 = extractvalue { i1, i1 } %"090.0", 0
-  %20 = extractvalue { i1, i1 } %"090.0", 1
-  %21 = extractvalue { i1, i1 } %"090.0", 1
-  %"0112.0" = select i1 %19, i1 %21, i1 %20
-  %22 = insertvalue { i1, { i1, i1 }, { i1, i1 } } { i1 false, { i1, i1 } poison, { i1, i1 } poison }, { i1, i1 } %"1.0", 1
-  %23 = insertvalue { i1, { i1, i1 }, { i1, i1 } } %22, { i1, i1 } %"191.0", 2
-  %24 = insertvalue { i1, { i1, i1 }, { i1, i1 } } { i1 true, { i1, i1 } poison, { i1, i1 } poison }, { i1, i1 } %"1.0", 1
-  %"0125.0" = select i1 %"0112.0", { i1, { i1, i1 }, { i1, i1 } } %24, { i1, { i1, i1 }, { i1, i1 } } %23
-  %25 = extractvalue { i1, { i1, i1 }, { i1, i1 } } %"0125.0", 0
-  %26 = extractvalue { i1, { i1, i1 }, { i1, i1 } } %"0125.0", 1
-  %27 = extractvalue { i1, { i1, i1 }, { i1, i1 } } %"0125.0", 2
-  %28 = extractvalue { i1, { i1, i1 }, { i1, i1 } } %"0125.0", 1
-  %"51_1.0" = select i1 %25, { i1, i1 } zeroinitializer, { i1, i1 } %27
-  %"51_0.0" = select i1 %25, { i1, i1 } %28, { i1, i1 } %26
-  %"51_0.0.reload.fca.1.extract" = extractvalue { i1, i1 } %"51_0.0", 1
-  %"51_1.0.reload.fca.1.extract" = extractvalue { i1, i1 } %"51_1.0", 1
+cond_65_case_1:                                   ; preds = %alloca_block
+  tail call void @__quantum__qis__phasedx__body(double 0x3FF921FB54442D18, double 0xBFF921FB54442D18, %Qubit* nonnull inttoptr (i64 1 to %Qubit*))
+  tail call void @__quantum__qis__rz__body(double 0x400921FB54442D18, %Qubit* nonnull inttoptr (i64 1 to %Qubit*))
+  tail call void @__quantum__qis__mz__body(%Qubit* nonnull inttoptr (i64 1 to %Qubit*), %Result* null)
+  %3 = tail call i1 @__quantum__qis__read_result__body(%Result* null)
   br label %cond_exit_178
 }
 
-declare void @__quantum__qis__phasedx__body(double, double, %Qubit*)
+declare void @__quantum__qis__phasedx__body(double, double, %Qubit*) local_unnamed_addr
 
-declare void @__quantum__qis__rz__body(double, %Qubit*)
+declare void @__quantum__qis__rz__body(double, %Qubit*) local_unnamed_addr
 
-declare void @__quantum__qis__mz__body(%Qubit*, %Result*)
+declare void @__quantum__qis__mz__body(%Qubit*, %Result*) local_unnamed_addr
 
-declare i1 @__quantum__qis__read_result__body(%Result*)
+declare i1 @__quantum__qis__read_result__body(%Result*) local_unnamed_addr
 
-declare void @__quantum__rt__bool_record_output(i1, i8*)
+declare void @__quantum__rt__bool_record_output(i1, i8*) local_unnamed_addr
 
 attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="custom" "required_num_qubits"="2" "required_num_results"="3" }
 

--- a/python/tests/snapshots/quantum-functions-1.ll
+++ b/python/tests/snapshots/quantum-functions-1.ll
@@ -1,5 +1,7 @@
 ; ModuleID = 'hugr-qir'
 source_filename = "hugr-qir"
+target datalayout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128"
+target triple = "aarch64-unknown-linux-gnu"
 
 %Qubit = type opaque
 %Result = type opaque
@@ -7,30 +9,30 @@ source_filename = "hugr-qir"
 @0 = private unnamed_addr constant [2 x i8] c"0\00", align 1
 @1 = private unnamed_addr constant [2 x i8] c"1\00", align 1
 
-define void @__hugr__.main.1() #0 {
+define void @__hugr__.main.1() local_unnamed_addr #0 {
 alloca_block:
-  call void @__quantum__qis__phasedx__body(double 0x3FF921FB54442D18, double 0xBFF921FB54442D18, %Qubit* null)
-  call void @__quantum__qis__rz__body(double 0x400921FB54442D18, %Qubit* null)
-  call void @__quantum__qis__phasedx__body(double 0x3FF921FB54442D18, double 0xBFF921FB54442D18, %Qubit* inttoptr (i64 1 to %Qubit*))
-  call void @__quantum__qis__rz__body(double 0x400921FB54442D18, %Qubit* inttoptr (i64 1 to %Qubit*))
-  call void @__quantum__qis__mz__body(%Qubit* null, %Result* null)
-  %0 = call i1 @__quantum__qis__read_result__body(%Result* null)
-  call void @__quantum__rt__bool_record_output(i1 %0, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
-  call void @__quantum__qis__mz__body(%Qubit* inttoptr (i64 1 to %Qubit*), %Result* inttoptr (i64 1 to %Result*))
-  %1 = call i1 @__quantum__qis__read_result__body(%Result* inttoptr (i64 1 to %Result*))
-  call void @__quantum__rt__bool_record_output(i1 %1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @1, i32 0, i32 0))
+  tail call void @__quantum__qis__phasedx__body(double 0x3FF921FB54442D18, double 0xBFF921FB54442D18, %Qubit* null)
+  tail call void @__quantum__qis__rz__body(double 0x400921FB54442D18, %Qubit* null)
+  tail call void @__quantum__qis__phasedx__body(double 0x3FF921FB54442D18, double 0xBFF921FB54442D18, %Qubit* nonnull inttoptr (i64 1 to %Qubit*))
+  tail call void @__quantum__qis__rz__body(double 0x400921FB54442D18, %Qubit* nonnull inttoptr (i64 1 to %Qubit*))
+  tail call void @__quantum__qis__mz__body(%Qubit* null, %Result* null)
+  %0 = tail call i1 @__quantum__qis__read_result__body(%Result* null)
+  tail call void @__quantum__rt__bool_record_output(i1 %0, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i64 0, i64 0))
+  tail call void @__quantum__qis__mz__body(%Qubit* nonnull inttoptr (i64 1 to %Qubit*), %Result* nonnull inttoptr (i64 1 to %Result*))
+  %1 = tail call i1 @__quantum__qis__read_result__body(%Result* nonnull inttoptr (i64 1 to %Result*))
+  tail call void @__quantum__rt__bool_record_output(i1 %1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @1, i64 0, i64 0))
   ret void
 }
 
-declare void @__quantum__qis__phasedx__body(double, double, %Qubit*)
+declare void @__quantum__qis__phasedx__body(double, double, %Qubit*) local_unnamed_addr
 
-declare void @__quantum__qis__rz__body(double, %Qubit*)
+declare void @__quantum__qis__rz__body(double, %Qubit*) local_unnamed_addr
 
-declare void @__quantum__qis__mz__body(%Qubit*, %Result*)
+declare void @__quantum__qis__mz__body(%Qubit*, %Result*) local_unnamed_addr
 
-declare i1 @__quantum__qis__read_result__body(%Result*)
+declare i1 @__quantum__qis__read_result__body(%Result*) local_unnamed_addr
 
-declare void @__quantum__rt__bool_record_output(i1, i8*)
+declare void @__quantum__rt__bool_record_output(i1, i8*) local_unnamed_addr
 
 attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="custom" "required_num_qubits"="2" "required_num_results"="2" }
 

--- a/python/tests/snapshots/quantum-functions-2.ll
+++ b/python/tests/snapshots/quantum-functions-2.ll
@@ -1,5 +1,7 @@
 ; ModuleID = 'hugr-qir'
 source_filename = "hugr-qir"
+target datalayout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128"
+target triple = "aarch64-unknown-linux-gnu"
 
 %Qubit = type opaque
 %Result = type opaque
@@ -7,30 +9,30 @@ source_filename = "hugr-qir"
 @0 = private unnamed_addr constant [2 x i8] c"0\00", align 1
 @1 = private unnamed_addr constant [2 x i8] c"1\00", align 1
 
-define void @__hugr__.main.1() #0 {
+define void @__hugr__.main.1() local_unnamed_addr #0 {
 alloca_block:
-  call void @__quantum__qis__phasedx__body(double 0x3FF921FB54442D18, double 0xBFF921FB54442D18, %Qubit* null)
-  call void @__quantum__qis__rz__body(double 0x400921FB54442D18, %Qubit* null)
-  call void @__quantum__qis__phasedx__body(double 0x3FF921FB54442D18, double 0xBFF921FB54442D18, %Qubit* inttoptr (i64 1 to %Qubit*))
-  call void @__quantum__qis__rz__body(double 0x400921FB54442D18, %Qubit* inttoptr (i64 1 to %Qubit*))
-  call void @__quantum__qis__mz__body(%Qubit* null, %Result* null)
-  %0 = call i1 @__quantum__qis__read_result__body(%Result* null)
-  call void @__quantum__rt__bool_record_output(i1 %0, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
-  call void @__quantum__qis__mz__body(%Qubit* inttoptr (i64 1 to %Qubit*), %Result* inttoptr (i64 1 to %Result*))
-  %1 = call i1 @__quantum__qis__read_result__body(%Result* inttoptr (i64 1 to %Result*))
-  call void @__quantum__rt__bool_record_output(i1 %1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @1, i32 0, i32 0))
+  tail call void @__quantum__qis__phasedx__body(double 0x3FF921FB54442D18, double 0xBFF921FB54442D18, %Qubit* null)
+  tail call void @__quantum__qis__rz__body(double 0x400921FB54442D18, %Qubit* null)
+  tail call void @__quantum__qis__phasedx__body(double 0x3FF921FB54442D18, double 0xBFF921FB54442D18, %Qubit* nonnull inttoptr (i64 1 to %Qubit*))
+  tail call void @__quantum__qis__rz__body(double 0x400921FB54442D18, %Qubit* nonnull inttoptr (i64 1 to %Qubit*))
+  tail call void @__quantum__qis__mz__body(%Qubit* null, %Result* null)
+  %0 = tail call i1 @__quantum__qis__read_result__body(%Result* null)
+  tail call void @__quantum__rt__bool_record_output(i1 %0, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i64 0, i64 0))
+  tail call void @__quantum__qis__mz__body(%Qubit* nonnull inttoptr (i64 1 to %Qubit*), %Result* nonnull inttoptr (i64 1 to %Result*))
+  %1 = tail call i1 @__quantum__qis__read_result__body(%Result* nonnull inttoptr (i64 1 to %Result*))
+  tail call void @__quantum__rt__bool_record_output(i1 %1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @1, i64 0, i64 0))
   ret void
 }
 
-declare void @__quantum__qis__phasedx__body(double, double, %Qubit*)
+declare void @__quantum__qis__phasedx__body(double, double, %Qubit*) local_unnamed_addr
 
-declare void @__quantum__qis__rz__body(double, %Qubit*)
+declare void @__quantum__qis__rz__body(double, %Qubit*) local_unnamed_addr
 
-declare void @__quantum__qis__mz__body(%Qubit*, %Result*)
+declare void @__quantum__qis__mz__body(%Qubit*, %Result*) local_unnamed_addr
 
-declare i1 @__quantum__qis__read_result__body(%Result*)
+declare i1 @__quantum__qis__read_result__body(%Result*) local_unnamed_addr
 
-declare void @__quantum__rt__bool_record_output(i1, i8*)
+declare void @__quantum__rt__bool_record_output(i1, i8*) local_unnamed_addr
 
 attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="custom" "required_num_qubits"="2" "required_num_results"="2" }
 

--- a/python/tests/snapshots/quantum-loop-1.ll
+++ b/python/tests/snapshots/quantum-loop-1.ll
@@ -1,5 +1,7 @@
 ; ModuleID = 'hugr-qir'
 source_filename = "hugr-qir"
+target datalayout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128"
+target triple = "aarch64-unknown-linux-gnu"
 
 %Qubit = type opaque
 %Result = type opaque
@@ -7,112 +9,46 @@ source_filename = "hugr-qir"
 @0 = private unnamed_addr constant [2 x i8] c"0\00", align 1
 @1 = private unnamed_addr constant [2 x i8] c"1\00", align 1
 
-define void @__hugr__.main.1() #0 {
+define void @__hugr__.main.1() local_unnamed_addr #0 {
 alloca_block:
-  br label %cond_exit_254
-
-cond_exit_254:                                    ; preds = %cond_exit_74, %alloca_block
-  %"19_1.0.reg2mem.0.reg2mem.0" = phi i64 [ 10, %alloca_block ], [ %27, %cond_exit_74 ]
-  %"19_0.0.reg2mem.0.reg2mem.0" = phi i64 [ 0, %alloca_block ], [ %26, %cond_exit_74 ]
-  %0 = icmp slt i64 %"19_0.0.reg2mem.0.reg2mem.0", %"19_1.0.reg2mem.0.reg2mem.0"
-  %1 = insertvalue { i1, i64, i64 } { i1 true, i64 poison, i64 poison }, i64 %"19_0.0.reg2mem.0.reg2mem.0", 1
-  %2 = insertvalue { i1, i64, i64 } %1, i64 %"19_1.0.reg2mem.0.reg2mem.0", 2
-  %"076.0" = select i1 %0, { i1, i64, i64 } %2, { i1, i64, i64 } { i1 false, i64 poison, i64 poison }
-  %3 = extractvalue { i1, i64, i64 } %"076.0", 0
-  br i1 %3, label %10, label %cond_exit_30
-
-cond_59_case_1:                                   ; preds = %19
-  call void @abort()
-  br label %cond_exit_59
-
-cond_74_case_1:                                   ; preds = %21
-  %4 = extractvalue { i1, { { i64, i64 }, i64 } } %"1112.0", 1
-  %.reload242.fca.0.0.extract = extractvalue { { i64, i64 }, i64 } %4, 0, 0
-  %.reload242.fca.0.1.extract = extractvalue { { i64, i64 }, i64 } %4, 0, 1
-  %.reload242.fca.1.extract = extractvalue { { i64, i64 }, i64 } %4, 1
-  br label %cond_exit_74
-
-cond_exit_30:                                     ; preds = %cond_exit_254, %10
-  %"053.0.reg2mem.sroa.0.0.reg2mem.0" = phi i1 [ %.reload238.fca.0.extract, %10 ], [ false, %cond_exit_254 ]
-  %"053.0.reg2mem.sroa.3.0.reg2mem.0" = phi i64 [ %.reload238.fca.1.0.0.extract, %10 ], [ poison, %cond_exit_254 ]
-  %"053.0.reg2mem.sroa.6.0.reg2mem.0" = phi i64 [ %.reload238.fca.1.0.1.extract, %10 ], [ poison, %cond_exit_254 ]
-  %"053.0.reg2mem.sroa.9.0.reg2mem.0" = phi i64 [ %.reload238.fca.1.1.extract, %10 ], [ poison, %cond_exit_254 ]
-  %"053.0.reload.fca.0.insert" = insertvalue { i1, { { i64, i64 }, i64 } } poison, i1 %"053.0.reg2mem.sroa.0.0.reg2mem.0", 0
-  %"053.0.reload.fca.1.0.0.insert" = insertvalue { i1, { { i64, i64 }, i64 } } %"053.0.reload.fca.0.insert", i64 %"053.0.reg2mem.sroa.3.0.reg2mem.0", 1, 0, 0
-  %"053.0.reload.fca.1.0.1.insert" = insertvalue { i1, { { i64, i64 }, i64 } } %"053.0.reload.fca.1.0.0.insert", i64 %"053.0.reg2mem.sroa.6.0.reg2mem.0", 1, 0, 1
-  %"053.0.reload.fca.1.1.insert" = insertvalue { i1, { { i64, i64 }, i64 } } %"053.0.reload.fca.1.0.1.insert", i64 %"053.0.reg2mem.sroa.9.0.reg2mem.0", 1, 1
-  %5 = extractvalue { i1, { { i64, i64 }, i64 } } %"053.0.reload.fca.1.1.insert", 1
-  %6 = insertvalue { i1, { { i64, i64 }, i64 } } { i1 true, { { i64, i64 }, i64 } poison }, { { i64, i64 }, i64 } %5, 1
-  %"0111.0" = select i1 %"053.0.reg2mem.sroa.0.0.reg2mem.0", { i1, i1 } { i1 false, i1 true }, { i1, i1 } zeroinitializer
-  %"1112.0" = select i1 %"053.0.reg2mem.sroa.0.0.reg2mem.0", { i1, { { i64, i64 }, i64 } } %6, { i1, { { i64, i64 }, i64 } } { i1 false, { { i64, i64 }, i64 } poison }
-  %7 = extractvalue { i1, i1 } %"0111.0", 0
-  %8 = extractvalue { i1, i1 } %"0111.0", 1
-  %9 = extractvalue { i1, i1 } %"0111.0", 1
-  %"0124.0" = select i1 %7, i1 %9, i1 %8
-  br i1 %"0124.0", label %21, label %19
-
-10:                                               ; preds = %cond_exit_254
-  %11 = extractvalue { i1, i64, i64 } %"076.0", 1
-  %12 = extractvalue { i1, i64, i64 } %"076.0", 2
-  %13 = add i64 %11, 1
-  %14 = insertvalue { i64, i64 } poison, i64 %13, 0
-  %15 = insertvalue { i64, i64 } %14, i64 %12, 1
-  %16 = insertvalue { { i64, i64 }, i64 } poison, i64 %11, 1
-  %17 = insertvalue { { i64, i64 }, i64 } %16, { i64, i64 } %15, 0
-  %18 = insertvalue { i1, { { i64, i64 }, i64 } } { i1 true, { { i64, i64 }, i64 } poison }, { { i64, i64 }, i64 } %17, 1
-  %.reload238.fca.0.extract = extractvalue { i1, { { i64, i64 }, i64 } } %18, 0
-  %.reload238.fca.1.0.0.extract = extractvalue { i1, { { i64, i64 }, i64 } } %18, 1, 0, 0
-  %.reload238.fca.1.0.1.extract = extractvalue { i1, { { i64, i64 }, i64 } } %18, 1, 0, 1
-  %.reload238.fca.1.1.extract = extractvalue { i1, { { i64, i64 }, i64 } } %18, 1, 1
-  br label %cond_exit_30
-
-19:                                               ; preds = %cond_exit_30
-  %20 = extractvalue { i1, { { i64, i64 }, i64 } } %"1112.0", 0
-  br i1 %20, label %cond_59_case_1, label %cond_exit_59
-
-21:                                               ; preds = %cond_exit_30
-  call void @__quantum__qis__phasedx__body(double 0x3FF921FB54442D18, double 0xBFF921FB54442D18, %Qubit* null)
-  call void @__quantum__qis__rz__body(double 0x400921FB54442D18, %Qubit* null)
-  %22 = extractvalue { i1, { { i64, i64 }, i64 } } %"1112.0", 0
-  br i1 %22, label %cond_74_case_1, label %cond_74_case_0
-
-cond_exit_59:                                     ; preds = %19, %cond_59_case_1
-  call void @__quantum__qis__mz__body(%Qubit* null, %Result* null)
-  %23 = call i1 @__quantum__qis__read_result__body(%Result* null)
-  call void @__quantum__rt__bool_record_output(i1 %23, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
-  call void @__quantum__qis__mz__body(%Qubit* inttoptr (i64 1 to %Qubit*), %Result* inttoptr (i64 1 to %Result*))
-  %24 = call i1 @__quantum__qis__read_result__body(%Result* inttoptr (i64 1 to %Result*))
-  call void @__quantum__rt__bool_record_output(i1 %24, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @1, i32 0, i32 0))
+  tail call void @__quantum__qis__phasedx__body(double 0x3FF921FB54442D18, double 0xBFF921FB54442D18, %Qubit* null)
+  tail call void @__quantum__qis__rz__body(double 0x400921FB54442D18, %Qubit* null)
+  tail call void @__quantum__qis__phasedx__body(double 0x3FF921FB54442D18, double 0xBFF921FB54442D18, %Qubit* null)
+  tail call void @__quantum__qis__rz__body(double 0x400921FB54442D18, %Qubit* null)
+  tail call void @__quantum__qis__phasedx__body(double 0x3FF921FB54442D18, double 0xBFF921FB54442D18, %Qubit* null)
+  tail call void @__quantum__qis__rz__body(double 0x400921FB54442D18, %Qubit* null)
+  tail call void @__quantum__qis__phasedx__body(double 0x3FF921FB54442D18, double 0xBFF921FB54442D18, %Qubit* null)
+  tail call void @__quantum__qis__rz__body(double 0x400921FB54442D18, %Qubit* null)
+  tail call void @__quantum__qis__phasedx__body(double 0x3FF921FB54442D18, double 0xBFF921FB54442D18, %Qubit* null)
+  tail call void @__quantum__qis__rz__body(double 0x400921FB54442D18, %Qubit* null)
+  tail call void @__quantum__qis__phasedx__body(double 0x3FF921FB54442D18, double 0xBFF921FB54442D18, %Qubit* null)
+  tail call void @__quantum__qis__rz__body(double 0x400921FB54442D18, %Qubit* null)
+  tail call void @__quantum__qis__phasedx__body(double 0x3FF921FB54442D18, double 0xBFF921FB54442D18, %Qubit* null)
+  tail call void @__quantum__qis__rz__body(double 0x400921FB54442D18, %Qubit* null)
+  tail call void @__quantum__qis__phasedx__body(double 0x3FF921FB54442D18, double 0xBFF921FB54442D18, %Qubit* null)
+  tail call void @__quantum__qis__rz__body(double 0x400921FB54442D18, %Qubit* null)
+  tail call void @__quantum__qis__phasedx__body(double 0x3FF921FB54442D18, double 0xBFF921FB54442D18, %Qubit* null)
+  tail call void @__quantum__qis__rz__body(double 0x400921FB54442D18, %Qubit* null)
+  tail call void @__quantum__qis__phasedx__body(double 0x3FF921FB54442D18, double 0xBFF921FB54442D18, %Qubit* null)
+  tail call void @__quantum__qis__rz__body(double 0x400921FB54442D18, %Qubit* null)
+  tail call void @__quantum__qis__mz__body(%Qubit* null, %Result* null)
+  %0 = tail call i1 @__quantum__qis__read_result__body(%Result* null)
+  tail call void @__quantum__rt__bool_record_output(i1 %0, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i64 0, i64 0))
+  tail call void @__quantum__qis__mz__body(%Qubit* nonnull inttoptr (i64 1 to %Qubit*), %Result* nonnull inttoptr (i64 1 to %Result*))
+  %1 = tail call i1 @__quantum__qis__read_result__body(%Result* nonnull inttoptr (i64 1 to %Result*))
+  tail call void @__quantum__rt__bool_record_output(i1 %1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @1, i64 0, i64 0))
   ret void
-
-cond_74_case_0:                                   ; preds = %21
-  call void @abort()
-  br label %cond_exit_74
-
-cond_exit_74:                                     ; preds = %cond_74_case_1, %cond_74_case_0
-  %"0205.0.reg2mem.sroa.0.0.reg2mem.0" = phi i64 [ %.reload242.fca.0.0.extract, %cond_74_case_1 ], [ 0, %cond_74_case_0 ]
-  %"0205.0.reg2mem.sroa.3.0.reg2mem.0" = phi i64 [ %.reload242.fca.0.1.extract, %cond_74_case_1 ], [ 0, %cond_74_case_0 ]
-  %"0205.0.reg2mem.sroa.6.0.reg2mem.0" = phi i64 [ %.reload242.fca.1.extract, %cond_74_case_1 ], [ 0, %cond_74_case_0 ]
-  %"0205.0.reload.fca.0.0.insert" = insertvalue { { i64, i64 }, i64 } poison, i64 %"0205.0.reg2mem.sroa.0.0.reg2mem.0", 0, 0
-  %"0205.0.reload.fca.0.1.insert" = insertvalue { { i64, i64 }, i64 } %"0205.0.reload.fca.0.0.insert", i64 %"0205.0.reg2mem.sroa.3.0.reg2mem.0", 0, 1
-  %"0205.0.reload.fca.1.insert" = insertvalue { { i64, i64 }, i64 } %"0205.0.reload.fca.0.1.insert", i64 %"0205.0.reg2mem.sroa.6.0.reg2mem.0", 1
-  %25 = extractvalue { { i64, i64 }, i64 } %"0205.0.reload.fca.1.insert", 0
-  %26 = extractvalue { i64, i64 } %25, 0
-  %27 = extractvalue { i64, i64 } %25, 1
-  br label %cond_exit_254
 }
 
-declare void @abort()
+declare void @__quantum__qis__mz__body(%Qubit*, %Result*) local_unnamed_addr
 
-declare void @__quantum__qis__mz__body(%Qubit*, %Result*)
+declare i1 @__quantum__qis__read_result__body(%Result*) local_unnamed_addr
 
-declare i1 @__quantum__qis__read_result__body(%Result*)
+declare void @__quantum__rt__bool_record_output(i1, i8*) local_unnamed_addr
 
-declare void @__quantum__rt__bool_record_output(i1, i8*)
+declare void @__quantum__qis__phasedx__body(double, double, %Qubit*) local_unnamed_addr
 
-declare void @__quantum__qis__phasedx__body(double, double, %Qubit*)
-
-declare void @__quantum__qis__rz__body(double, %Qubit*)
+declare void @__quantum__qis__rz__body(double, %Qubit*) local_unnamed_addr
 
 attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="custom" "required_num_qubits"="2" "required_num_results"="2" }
 

--- a/python/tests/snapshots/quantum-loop-2.ll
+++ b/python/tests/snapshots/quantum-loop-2.ll
@@ -1,5 +1,7 @@
 ; ModuleID = 'hugr-qir'
 source_filename = "hugr-qir"
+target datalayout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128"
+target triple = "aarch64-unknown-linux-gnu"
 
 %Qubit = type opaque
 %Result = type opaque
@@ -7,122 +9,146 @@ source_filename = "hugr-qir"
 @0 = private unnamed_addr constant [2 x i8] c"0\00", align 1
 @1 = private unnamed_addr constant [2 x i8] c"1\00", align 1
 
-define void @__hugr__.main.1() #0 {
+define void @__hugr__.main.1() local_unnamed_addr #0 {
 alloca_block:
-  br label %cond_exit_309
+  tail call void @__quantum__qis__phasedx__body(double 0x3FF921FB54442D18, double 0xBFF921FB54442D18, %Qubit* nonnull inttoptr (i64 2 to %Qubit*))
+  tail call void @__quantum__qis__rz__body(double 0x400921FB54442D18, %Qubit* nonnull inttoptr (i64 2 to %Qubit*))
+  tail call void @__quantum__qis__mz__body(%Qubit* nonnull inttoptr (i64 2 to %Qubit*), %Result* nonnull inttoptr (i64 2 to %Result*))
+  %0 = tail call i1 @__quantum__qis__read_result__body(%Result* nonnull inttoptr (i64 2 to %Result*))
+  br i1 %0, label %21, label %cond_309_case_0
 
-cond_exit_309:                                    ; preds = %cond_exit_259._crit_edge, %alloca_block
-  %"19_1.0.reg2mem.0.reg2mem.0" = phi i64 [ 10, %alloca_block ], [ %28, %cond_exit_259._crit_edge ]
-  %"19_0.0.reg2mem.0.reg2mem.0" = phi i64 [ 0, %alloca_block ], [ %27, %cond_exit_259._crit_edge ]
-  %0 = icmp slt i64 %"19_0.0.reg2mem.0.reg2mem.0", %"19_1.0.reg2mem.0.reg2mem.0"
-  %1 = insertvalue { i1, i64, i64 } { i1 true, i64 poison, i64 poison }, i64 %"19_0.0.reg2mem.0.reg2mem.0", 1
-  %2 = insertvalue { i1, i64, i64 } %1, i64 %"19_1.0.reg2mem.0.reg2mem.0", 2
-  %"076.0" = select i1 %0, { i1, i64, i64 } %2, { i1, i64, i64 } { i1 false, i64 poison, i64 poison }
-  %3 = extractvalue { i1, i64, i64 } %"076.0", 0
-  br i1 %3, label %10, label %cond_exit_30
+cond_309_case_0:                                  ; preds = %alloca_block, %21
+  tail call void @__quantum__qis__phasedx__body(double 0x3FF921FB54442D18, double 0xBFF921FB54442D18, %Qubit* nonnull inttoptr (i64 2 to %Qubit*))
+  tail call void @__quantum__qis__rz__body(double 0x400921FB54442D18, %Qubit* nonnull inttoptr (i64 2 to %Qubit*))
+  tail call void @__quantum__qis__mz__body(%Qubit* nonnull inttoptr (i64 2 to %Qubit*), %Result* nonnull inttoptr (i64 2 to %Result*))
+  %1 = tail call i1 @__quantum__qis__read_result__body(%Result* nonnull inttoptr (i64 2 to %Result*))
+  br i1 %1, label %2, label %cond_309_case_0.1
 
-cond_59_case_1:                                   ; preds = %19
-  call void @abort()
-  br label %cond_exit_59
+2:                                                ; preds = %cond_309_case_0
+  tail call void @__quantum__qis__phasedx__body(double 0x3FF921FB54442D18, double 0xBFF921FB54442D18, %Qubit* null)
+  tail call void @__quantum__qis__rz__body(double 0x400921FB54442D18, %Qubit* null)
+  br label %cond_309_case_0.1
 
-cond_74_case_1:                                   ; preds = %21
-  %4 = extractvalue { i1, { { i64, i64 }, i64 } } %"1112.0", 1
-  %.reload319.fca.0.0.extract = extractvalue { { i64, i64 }, i64 } %4, 0, 0
-  %.reload319.fca.0.1.extract = extractvalue { { i64, i64 }, i64 } %4, 0, 1
-  %.reload319.fca.1.extract = extractvalue { { i64, i64 }, i64 } %4, 1
-  br label %cond_exit_259
+cond_309_case_0.1:                                ; preds = %2, %cond_309_case_0
+  tail call void @__quantum__qis__phasedx__body(double 0x3FF921FB54442D18, double 0xBFF921FB54442D18, %Qubit* nonnull inttoptr (i64 2 to %Qubit*))
+  tail call void @__quantum__qis__rz__body(double 0x400921FB54442D18, %Qubit* nonnull inttoptr (i64 2 to %Qubit*))
+  tail call void @__quantum__qis__mz__body(%Qubit* nonnull inttoptr (i64 2 to %Qubit*), %Result* nonnull inttoptr (i64 2 to %Result*))
+  %3 = tail call i1 @__quantum__qis__read_result__body(%Result* nonnull inttoptr (i64 2 to %Result*))
+  br i1 %3, label %4, label %cond_309_case_0.2
 
-cond_exit_259._crit_edge:                         ; preds = %cond_exit_259, %29
-  br label %cond_exit_309
+4:                                                ; preds = %cond_309_case_0.1
+  tail call void @__quantum__qis__phasedx__body(double 0x3FF921FB54442D18, double 0xBFF921FB54442D18, %Qubit* null)
+  tail call void @__quantum__qis__rz__body(double 0x400921FB54442D18, %Qubit* null)
+  br label %cond_309_case_0.2
 
-cond_exit_30:                                     ; preds = %cond_exit_309, %10
-  %"053.0.reg2mem.sroa.0.0.reg2mem.0" = phi i1 [ %.reload315.fca.0.extract, %10 ], [ false, %cond_exit_309 ]
-  %"053.0.reg2mem.sroa.3.0.reg2mem.0" = phi i64 [ %.reload315.fca.1.0.0.extract, %10 ], [ poison, %cond_exit_309 ]
-  %"053.0.reg2mem.sroa.6.0.reg2mem.0" = phi i64 [ %.reload315.fca.1.0.1.extract, %10 ], [ poison, %cond_exit_309 ]
-  %"053.0.reg2mem.sroa.9.0.reg2mem.0" = phi i64 [ %.reload315.fca.1.1.extract, %10 ], [ poison, %cond_exit_309 ]
-  %"053.0.reload.fca.0.insert" = insertvalue { i1, { { i64, i64 }, i64 } } poison, i1 %"053.0.reg2mem.sroa.0.0.reg2mem.0", 0
-  %"053.0.reload.fca.1.0.0.insert" = insertvalue { i1, { { i64, i64 }, i64 } } %"053.0.reload.fca.0.insert", i64 %"053.0.reg2mem.sroa.3.0.reg2mem.0", 1, 0, 0
-  %"053.0.reload.fca.1.0.1.insert" = insertvalue { i1, { { i64, i64 }, i64 } } %"053.0.reload.fca.1.0.0.insert", i64 %"053.0.reg2mem.sroa.6.0.reg2mem.0", 1, 0, 1
-  %"053.0.reload.fca.1.1.insert" = insertvalue { i1, { { i64, i64 }, i64 } } %"053.0.reload.fca.1.0.1.insert", i64 %"053.0.reg2mem.sroa.9.0.reg2mem.0", 1, 1
-  %5 = extractvalue { i1, { { i64, i64 }, i64 } } %"053.0.reload.fca.1.1.insert", 1
-  %6 = insertvalue { i1, { { i64, i64 }, i64 } } { i1 true, { { i64, i64 }, i64 } poison }, { { i64, i64 }, i64 } %5, 1
-  %"0111.0" = select i1 %"053.0.reg2mem.sroa.0.0.reg2mem.0", { i1, i1 } { i1 false, i1 true }, { i1, i1 } zeroinitializer
-  %"1112.0" = select i1 %"053.0.reg2mem.sroa.0.0.reg2mem.0", { i1, { { i64, i64 }, i64 } } %6, { i1, { { i64, i64 }, i64 } } { i1 false, { { i64, i64 }, i64 } poison }
-  %7 = extractvalue { i1, i1 } %"0111.0", 0
-  %8 = extractvalue { i1, i1 } %"0111.0", 1
-  %9 = extractvalue { i1, i1 } %"0111.0", 1
-  %"0124.0" = select i1 %7, i1 %9, i1 %8
-  br i1 %"0124.0", label %21, label %19
+cond_309_case_0.2:                                ; preds = %4, %cond_309_case_0.1
+  tail call void @__quantum__qis__phasedx__body(double 0x3FF921FB54442D18, double 0xBFF921FB54442D18, %Qubit* nonnull inttoptr (i64 2 to %Qubit*))
+  tail call void @__quantum__qis__rz__body(double 0x400921FB54442D18, %Qubit* nonnull inttoptr (i64 2 to %Qubit*))
+  tail call void @__quantum__qis__mz__body(%Qubit* nonnull inttoptr (i64 2 to %Qubit*), %Result* nonnull inttoptr (i64 2 to %Result*))
+  %5 = tail call i1 @__quantum__qis__read_result__body(%Result* nonnull inttoptr (i64 2 to %Result*))
+  br i1 %5, label %6, label %cond_309_case_0.3
 
-10:                                               ; preds = %cond_exit_309
-  %11 = extractvalue { i1, i64, i64 } %"076.0", 1
-  %12 = extractvalue { i1, i64, i64 } %"076.0", 2
-  %13 = add i64 %11, 1
-  %14 = insertvalue { i64, i64 } poison, i64 %13, 0
-  %15 = insertvalue { i64, i64 } %14, i64 %12, 1
-  %16 = insertvalue { { i64, i64 }, i64 } poison, i64 %11, 1
-  %17 = insertvalue { { i64, i64 }, i64 } %16, { i64, i64 } %15, 0
-  %18 = insertvalue { i1, { { i64, i64 }, i64 } } { i1 true, { { i64, i64 }, i64 } poison }, { { i64, i64 }, i64 } %17, 1
-  %.reload315.fca.0.extract = extractvalue { i1, { { i64, i64 }, i64 } } %18, 0
-  %.reload315.fca.1.0.0.extract = extractvalue { i1, { { i64, i64 }, i64 } } %18, 1, 0, 0
-  %.reload315.fca.1.0.1.extract = extractvalue { i1, { { i64, i64 }, i64 } } %18, 1, 0, 1
-  %.reload315.fca.1.1.extract = extractvalue { i1, { { i64, i64 }, i64 } } %18, 1, 1
-  br label %cond_exit_30
+6:                                                ; preds = %cond_309_case_0.2
+  tail call void @__quantum__qis__phasedx__body(double 0x3FF921FB54442D18, double 0xBFF921FB54442D18, %Qubit* null)
+  tail call void @__quantum__qis__rz__body(double 0x400921FB54442D18, %Qubit* null)
+  br label %cond_309_case_0.3
 
-19:                                               ; preds = %cond_exit_30
-  %20 = extractvalue { i1, { { i64, i64 }, i64 } } %"1112.0", 0
-  br i1 %20, label %cond_59_case_1, label %cond_exit_59
+cond_309_case_0.3:                                ; preds = %6, %cond_309_case_0.2
+  tail call void @__quantum__qis__phasedx__body(double 0x3FF921FB54442D18, double 0xBFF921FB54442D18, %Qubit* nonnull inttoptr (i64 2 to %Qubit*))
+  tail call void @__quantum__qis__rz__body(double 0x400921FB54442D18, %Qubit* nonnull inttoptr (i64 2 to %Qubit*))
+  tail call void @__quantum__qis__mz__body(%Qubit* nonnull inttoptr (i64 2 to %Qubit*), %Result* nonnull inttoptr (i64 2 to %Result*))
+  %7 = tail call i1 @__quantum__qis__read_result__body(%Result* nonnull inttoptr (i64 2 to %Result*))
+  br i1 %7, label %8, label %cond_309_case_0.4
 
-21:                                               ; preds = %cond_exit_30
-  %22 = extractvalue { i1, { { i64, i64 }, i64 } } %"1112.0", 0
-  br i1 %22, label %cond_74_case_1, label %cond_74_case_0
+8:                                                ; preds = %cond_309_case_0.3
+  tail call void @__quantum__qis__phasedx__body(double 0x3FF921FB54442D18, double 0xBFF921FB54442D18, %Qubit* null)
+  tail call void @__quantum__qis__rz__body(double 0x400921FB54442D18, %Qubit* null)
+  br label %cond_309_case_0.4
 
-cond_exit_59:                                     ; preds = %19, %cond_59_case_1
-  call void @__quantum__qis__mz__body(%Qubit* null, %Result* null)
-  %23 = call i1 @__quantum__qis__read_result__body(%Result* null)
-  call void @__quantum__rt__bool_record_output(i1 %23, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
-  call void @__quantum__qis__mz__body(%Qubit* inttoptr (i64 1 to %Qubit*), %Result* inttoptr (i64 1 to %Result*))
-  %24 = call i1 @__quantum__qis__read_result__body(%Result* inttoptr (i64 1 to %Result*))
-  call void @__quantum__rt__bool_record_output(i1 %24, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @1, i32 0, i32 0))
+cond_309_case_0.4:                                ; preds = %8, %cond_309_case_0.3
+  tail call void @__quantum__qis__phasedx__body(double 0x3FF921FB54442D18, double 0xBFF921FB54442D18, %Qubit* nonnull inttoptr (i64 2 to %Qubit*))
+  tail call void @__quantum__qis__rz__body(double 0x400921FB54442D18, %Qubit* nonnull inttoptr (i64 2 to %Qubit*))
+  tail call void @__quantum__qis__mz__body(%Qubit* nonnull inttoptr (i64 2 to %Qubit*), %Result* nonnull inttoptr (i64 2 to %Result*))
+  %9 = tail call i1 @__quantum__qis__read_result__body(%Result* nonnull inttoptr (i64 2 to %Result*))
+  br i1 %9, label %10, label %cond_309_case_0.5
+
+10:                                               ; preds = %cond_309_case_0.4
+  tail call void @__quantum__qis__phasedx__body(double 0x3FF921FB54442D18, double 0xBFF921FB54442D18, %Qubit* null)
+  tail call void @__quantum__qis__rz__body(double 0x400921FB54442D18, %Qubit* null)
+  br label %cond_309_case_0.5
+
+cond_309_case_0.5:                                ; preds = %10, %cond_309_case_0.4
+  tail call void @__quantum__qis__phasedx__body(double 0x3FF921FB54442D18, double 0xBFF921FB54442D18, %Qubit* nonnull inttoptr (i64 2 to %Qubit*))
+  tail call void @__quantum__qis__rz__body(double 0x400921FB54442D18, %Qubit* nonnull inttoptr (i64 2 to %Qubit*))
+  tail call void @__quantum__qis__mz__body(%Qubit* nonnull inttoptr (i64 2 to %Qubit*), %Result* nonnull inttoptr (i64 2 to %Result*))
+  %11 = tail call i1 @__quantum__qis__read_result__body(%Result* nonnull inttoptr (i64 2 to %Result*))
+  br i1 %11, label %12, label %cond_309_case_0.6
+
+12:                                               ; preds = %cond_309_case_0.5
+  tail call void @__quantum__qis__phasedx__body(double 0x3FF921FB54442D18, double 0xBFF921FB54442D18, %Qubit* null)
+  tail call void @__quantum__qis__rz__body(double 0x400921FB54442D18, %Qubit* null)
+  br label %cond_309_case_0.6
+
+cond_309_case_0.6:                                ; preds = %12, %cond_309_case_0.5
+  tail call void @__quantum__qis__phasedx__body(double 0x3FF921FB54442D18, double 0xBFF921FB54442D18, %Qubit* nonnull inttoptr (i64 2 to %Qubit*))
+  tail call void @__quantum__qis__rz__body(double 0x400921FB54442D18, %Qubit* nonnull inttoptr (i64 2 to %Qubit*))
+  tail call void @__quantum__qis__mz__body(%Qubit* nonnull inttoptr (i64 2 to %Qubit*), %Result* nonnull inttoptr (i64 2 to %Result*))
+  %13 = tail call i1 @__quantum__qis__read_result__body(%Result* nonnull inttoptr (i64 2 to %Result*))
+  br i1 %13, label %14, label %cond_309_case_0.7
+
+14:                                               ; preds = %cond_309_case_0.6
+  tail call void @__quantum__qis__phasedx__body(double 0x3FF921FB54442D18, double 0xBFF921FB54442D18, %Qubit* null)
+  tail call void @__quantum__qis__rz__body(double 0x400921FB54442D18, %Qubit* null)
+  br label %cond_309_case_0.7
+
+cond_309_case_0.7:                                ; preds = %14, %cond_309_case_0.6
+  tail call void @__quantum__qis__phasedx__body(double 0x3FF921FB54442D18, double 0xBFF921FB54442D18, %Qubit* nonnull inttoptr (i64 2 to %Qubit*))
+  tail call void @__quantum__qis__rz__body(double 0x400921FB54442D18, %Qubit* nonnull inttoptr (i64 2 to %Qubit*))
+  tail call void @__quantum__qis__mz__body(%Qubit* nonnull inttoptr (i64 2 to %Qubit*), %Result* nonnull inttoptr (i64 2 to %Result*))
+  %15 = tail call i1 @__quantum__qis__read_result__body(%Result* nonnull inttoptr (i64 2 to %Result*))
+  br i1 %15, label %16, label %cond_309_case_0.8
+
+16:                                               ; preds = %cond_309_case_0.7
+  tail call void @__quantum__qis__phasedx__body(double 0x3FF921FB54442D18, double 0xBFF921FB54442D18, %Qubit* null)
+  tail call void @__quantum__qis__rz__body(double 0x400921FB54442D18, %Qubit* null)
+  br label %cond_309_case_0.8
+
+cond_309_case_0.8:                                ; preds = %16, %cond_309_case_0.7
+  tail call void @__quantum__qis__phasedx__body(double 0x3FF921FB54442D18, double 0xBFF921FB54442D18, %Qubit* nonnull inttoptr (i64 2 to %Qubit*))
+  tail call void @__quantum__qis__rz__body(double 0x400921FB54442D18, %Qubit* nonnull inttoptr (i64 2 to %Qubit*))
+  tail call void @__quantum__qis__mz__body(%Qubit* nonnull inttoptr (i64 2 to %Qubit*), %Result* nonnull inttoptr (i64 2 to %Result*))
+  %17 = tail call i1 @__quantum__qis__read_result__body(%Result* nonnull inttoptr (i64 2 to %Result*))
+  br i1 %17, label %18, label %cond_309_case_0.9
+
+18:                                               ; preds = %cond_309_case_0.8
+  tail call void @__quantum__qis__phasedx__body(double 0x3FF921FB54442D18, double 0xBFF921FB54442D18, %Qubit* null)
+  tail call void @__quantum__qis__rz__body(double 0x400921FB54442D18, %Qubit* null)
+  br label %cond_309_case_0.9
+
+cond_309_case_0.9:                                ; preds = %18, %cond_309_case_0.8
+  tail call void @__quantum__qis__mz__body(%Qubit* null, %Result* null)
+  %19 = tail call i1 @__quantum__qis__read_result__body(%Result* null)
+  tail call void @__quantum__rt__bool_record_output(i1 %19, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i64 0, i64 0))
+  tail call void @__quantum__qis__mz__body(%Qubit* nonnull inttoptr (i64 1 to %Qubit*), %Result* nonnull inttoptr (i64 1 to %Result*))
+  %20 = tail call i1 @__quantum__qis__read_result__body(%Result* nonnull inttoptr (i64 1 to %Result*))
+  tail call void @__quantum__rt__bool_record_output(i1 %20, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @1, i64 0, i64 0))
   ret void
 
-cond_74_case_0:                                   ; preds = %21
-  call void @abort()
-  br label %cond_exit_259
-
-cond_exit_259:                                    ; preds = %cond_74_case_1, %cond_74_case_0
-  %"0198.0.reg2mem.sroa.0.0.reg2mem.0" = phi i64 [ %.reload319.fca.0.0.extract, %cond_74_case_1 ], [ 0, %cond_74_case_0 ]
-  %"0198.0.reg2mem.sroa.3.0.reg2mem.0" = phi i64 [ %.reload319.fca.0.1.extract, %cond_74_case_1 ], [ 0, %cond_74_case_0 ]
-  %"0198.0.reg2mem.sroa.6.0.reg2mem.0" = phi i64 [ %.reload319.fca.1.extract, %cond_74_case_1 ], [ 0, %cond_74_case_0 ]
-  %"0198.0.reload.fca.0.0.insert" = insertvalue { { i64, i64 }, i64 } poison, i64 %"0198.0.reg2mem.sroa.0.0.reg2mem.0", 0, 0
-  %"0198.0.reload.fca.0.1.insert" = insertvalue { { i64, i64 }, i64 } %"0198.0.reload.fca.0.0.insert", i64 %"0198.0.reg2mem.sroa.3.0.reg2mem.0", 0, 1
-  %"0198.0.reload.fca.1.insert" = insertvalue { { i64, i64 }, i64 } %"0198.0.reload.fca.0.1.insert", i64 %"0198.0.reg2mem.sroa.6.0.reg2mem.0", 1
-  call void @__quantum__qis__phasedx__body(double 0x3FF921FB54442D18, double 0xBFF921FB54442D18, %Qubit* inttoptr (i64 2 to %Qubit*))
-  call void @__quantum__qis__rz__body(double 0x400921FB54442D18, %Qubit* inttoptr (i64 2 to %Qubit*))
-  call void @__quantum__qis__mz__body(%Qubit* inttoptr (i64 2 to %Qubit*), %Result* inttoptr (i64 2 to %Result*))
-  %25 = call i1 @__quantum__qis__read_result__body(%Result* inttoptr (i64 2 to %Result*))
-  %26 = extractvalue { { i64, i64 }, i64 } %"0198.0.reload.fca.1.insert", 0
-  %27 = extractvalue { i64, i64 } %26, 0
-  %28 = extractvalue { i64, i64 } %26, 1
-  br i1 %25, label %29, label %cond_exit_259._crit_edge
-
-29:                                               ; preds = %cond_exit_259
-  call void @__quantum__qis__phasedx__body(double 0x3FF921FB54442D18, double 0xBFF921FB54442D18, %Qubit* null)
-  call void @__quantum__qis__rz__body(double 0x400921FB54442D18, %Qubit* null)
-  br label %cond_exit_259._crit_edge
+21:                                               ; preds = %alloca_block
+  tail call void @__quantum__qis__phasedx__body(double 0x3FF921FB54442D18, double 0xBFF921FB54442D18, %Qubit* null)
+  tail call void @__quantum__qis__rz__body(double 0x400921FB54442D18, %Qubit* null)
+  br label %cond_309_case_0
 }
 
-declare void @abort()
+declare void @__quantum__qis__mz__body(%Qubit*, %Result*) local_unnamed_addr
 
-declare void @__quantum__qis__mz__body(%Qubit*, %Result*)
+declare i1 @__quantum__qis__read_result__body(%Result*) local_unnamed_addr
 
-declare i1 @__quantum__qis__read_result__body(%Result*)
+declare void @__quantum__rt__bool_record_output(i1, i8*) local_unnamed_addr
 
-declare void @__quantum__rt__bool_record_output(i1, i8*)
+declare void @__quantum__qis__phasedx__body(double, double, %Qubit*) local_unnamed_addr
 
-declare void @__quantum__qis__phasedx__body(double, double, %Qubit*)
-
-declare void @__quantum__qis__rz__body(double, %Qubit*)
+declare void @__quantum__qis__rz__body(double, %Qubit*) local_unnamed_addr
 
 attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="custom" "required_num_qubits"="3" "required_num_results"="3" }
 

--- a/python/tests/snapshots/quantum-simple-1.ll
+++ b/python/tests/snapshots/quantum-simple-1.ll
@@ -1,30 +1,32 @@
 ; ModuleID = 'hugr-qir'
 source_filename = "hugr-qir"
+target datalayout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128"
+target triple = "aarch64-unknown-linux-gnu"
 
 %Qubit = type opaque
 %Result = type opaque
 
 @0 = private unnamed_addr constant [2 x i8] c"0\00", align 1
 
-define void @__hugr__.main.1() #0 {
+define void @__hugr__.main.1() local_unnamed_addr #0 {
 alloca_block:
-  call void @__quantum__qis__phasedx__body(double 0x3FF921FB54442D18, double 0xBFF921FB54442D18, %Qubit* null)
-  call void @__quantum__qis__rz__body(double 0x400921FB54442D18, %Qubit* null)
-  call void @__quantum__qis__mz__body(%Qubit* null, %Result* null)
-  %0 = call i1 @__quantum__qis__read_result__body(%Result* null)
-  call void @__quantum__rt__bool_record_output(i1 %0, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
+  tail call void @__quantum__qis__phasedx__body(double 0x3FF921FB54442D18, double 0xBFF921FB54442D18, %Qubit* null)
+  tail call void @__quantum__qis__rz__body(double 0x400921FB54442D18, %Qubit* null)
+  tail call void @__quantum__qis__mz__body(%Qubit* null, %Result* null)
+  %0 = tail call i1 @__quantum__qis__read_result__body(%Result* null)
+  tail call void @__quantum__rt__bool_record_output(i1 %0, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i64 0, i64 0))
   ret void
 }
 
-declare void @__quantum__qis__phasedx__body(double, double, %Qubit*)
+declare void @__quantum__qis__phasedx__body(double, double, %Qubit*) local_unnamed_addr
 
-declare void @__quantum__qis__rz__body(double, %Qubit*)
+declare void @__quantum__qis__rz__body(double, %Qubit*) local_unnamed_addr
 
-declare void @__quantum__qis__mz__body(%Qubit*, %Result*)
+declare void @__quantum__qis__mz__body(%Qubit*, %Result*) local_unnamed_addr
 
-declare i1 @__quantum__qis__read_result__body(%Result*)
+declare i1 @__quantum__qis__read_result__body(%Result*) local_unnamed_addr
 
-declare void @__quantum__rt__bool_record_output(i1, i8*)
+declare void @__quantum__rt__bool_record_output(i1, i8*) local_unnamed_addr
 
 attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="custom" "required_num_qubits"="1" "required_num_results"="1" }
 

--- a/python/tests/snapshots/quantum-simple-2.ll
+++ b/python/tests/snapshots/quantum-simple-2.ll
@@ -1,5 +1,7 @@
 ; ModuleID = 'hugr-qir'
 source_filename = "hugr-qir"
+target datalayout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128"
+target triple = "aarch64-unknown-linux-gnu"
 
 %Qubit = type opaque
 %Result = type opaque
@@ -7,30 +9,30 @@ source_filename = "hugr-qir"
 @0 = private unnamed_addr constant [2 x i8] c"0\00", align 1
 @1 = private unnamed_addr constant [2 x i8] c"1\00", align 1
 
-define void @__hugr__.main.1() #0 {
+define void @__hugr__.main.1() local_unnamed_addr #0 {
 alloca_block:
-  call void @__quantum__qis__mz__body(%Qubit* null, %Result* null)
-  %0 = call i1 @__quantum__qis__read_result__body(%Result* null)
-  call void @__quantum__rt__bool_record_output(i1 %0, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
-  call void @__quantum__qis__phasedx__body(double 0x3FF921FB54442D18, double 0xBFF921FB54442D18, %Qubit* inttoptr (i64 1 to %Qubit*))
-  call void @__quantum__qis__rz__body(double 0x400921FB54442D18, %Qubit* inttoptr (i64 1 to %Qubit*))
-  call void @__quantum__qis__phasedx__body(double 0x3FF921FB54442D18, double 0xBFF921FB54442D18, %Qubit* inttoptr (i64 1 to %Qubit*))
-  call void @__quantum__qis__rz__body(double 0x400921FB54442D18, %Qubit* inttoptr (i64 1 to %Qubit*))
-  call void @__quantum__qis__mz__body(%Qubit* inttoptr (i64 1 to %Qubit*), %Result* inttoptr (i64 1 to %Result*))
-  %1 = call i1 @__quantum__qis__read_result__body(%Result* inttoptr (i64 1 to %Result*))
-  call void @__quantum__rt__bool_record_output(i1 %1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @1, i32 0, i32 0))
+  tail call void @__quantum__qis__mz__body(%Qubit* null, %Result* null)
+  %0 = tail call i1 @__quantum__qis__read_result__body(%Result* null)
+  tail call void @__quantum__rt__bool_record_output(i1 %0, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i64 0, i64 0))
+  tail call void @__quantum__qis__phasedx__body(double 0x3FF921FB54442D18, double 0xBFF921FB54442D18, %Qubit* nonnull inttoptr (i64 1 to %Qubit*))
+  tail call void @__quantum__qis__rz__body(double 0x400921FB54442D18, %Qubit* nonnull inttoptr (i64 1 to %Qubit*))
+  tail call void @__quantum__qis__phasedx__body(double 0x3FF921FB54442D18, double 0xBFF921FB54442D18, %Qubit* nonnull inttoptr (i64 1 to %Qubit*))
+  tail call void @__quantum__qis__rz__body(double 0x400921FB54442D18, %Qubit* nonnull inttoptr (i64 1 to %Qubit*))
+  tail call void @__quantum__qis__mz__body(%Qubit* nonnull inttoptr (i64 1 to %Qubit*), %Result* nonnull inttoptr (i64 1 to %Result*))
+  %1 = tail call i1 @__quantum__qis__read_result__body(%Result* nonnull inttoptr (i64 1 to %Result*))
+  tail call void @__quantum__rt__bool_record_output(i1 %1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @1, i64 0, i64 0))
   ret void
 }
 
-declare void @__quantum__qis__mz__body(%Qubit*, %Result*)
+declare void @__quantum__qis__mz__body(%Qubit*, %Result*) local_unnamed_addr
 
-declare i1 @__quantum__qis__read_result__body(%Result*)
+declare i1 @__quantum__qis__read_result__body(%Result*) local_unnamed_addr
 
-declare void @__quantum__rt__bool_record_output(i1, i8*)
+declare void @__quantum__rt__bool_record_output(i1, i8*) local_unnamed_addr
 
-declare void @__quantum__qis__phasedx__body(double, double, %Qubit*)
+declare void @__quantum__qis__phasedx__body(double, double, %Qubit*) local_unnamed_addr
 
-declare void @__quantum__qis__rz__body(double, %Qubit*)
+declare void @__quantum__qis__rz__body(double, %Qubit*) local_unnamed_addr
 
 attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="custom" "required_num_qubits"="2" "required_num_results"="2" }
 

--- a/python/tests/test_hugr_to_qir.py
+++ b/python/tests/test_hugr_to_qir.py
@@ -14,11 +14,7 @@ from pytest_snapshot.plugin import Snapshot  # type: ignore
 from .conftest import guppy_files, guppy_to_hugr_binary
 
 SNAPSHOT_DIR = Path(__file__).parent / "snapshots"
-GUPPY_EXAMPLES_XFAIL = [
-    "quantum-loop-1.py",
-    "quantum-loop-2.py",
-    "quantum-conditional-2.py",
-]
+GUPPY_EXAMPLES_XFAIL = []
 
 guppy_files_xpass = [
     guppy_file

--- a/python/tests/test_hugr_to_qir.py
+++ b/python/tests/test_hugr_to_qir.py
@@ -14,7 +14,7 @@ from pytest_snapshot.plugin import Snapshot  # type: ignore
 from .conftest import guppy_files, guppy_to_hugr_binary
 
 SNAPSHOT_DIR = Path(__file__).parent / "snapshots"
-GUPPY_EXAMPLES_XFAIL = []
+GUPPY_EXAMPLES_XFAIL: list[str] = []
 
 guppy_files_xpass = [
     guppy_file

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,13 +20,10 @@ use inkwell::context::Context;
 use inkwell::module::Module;
 use qir::{QirCodegenExtension, QirPreludeCodegen};
 use rotation::RotationCodegenExtension;
-use std::error::Error;
 use target::CompileTarget;
 pub mod cli;
 pub mod qir;
 pub mod target;
-use crate::inkwell::support::LLVMString;
-use std::fmt::{self, Display, Formatter};
 
 #[cfg(feature = "py")]
 mod py;
@@ -127,9 +124,7 @@ impl CompileArgs {
         module.set_triple(&ctm.get_triple());
         module.set_data_layout(&ctm.get_target_data().get_data_layout());
 
-        module
-            .run_passes(Self::OPT_LEVEL_STR, &ctm, PassBuilderOptions::create())
-            .map_err(Into::<ProcessErrs>::into)?;
+        let _ = module.run_passes(Self::OPT_LEVEL_STR, &ctm, PassBuilderOptions::create());
         Ok(())
     }
 
@@ -157,9 +152,6 @@ impl CompileArgs {
         Ok(module)
     }
 }
-
-
-impl Error for ProcessErrs {}
 
 pub fn find_hugr_entry_point(hugr: &impl HugrView<Node = Node>) -> Result<Node> {
     let entry_point_node = {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -158,42 +158,6 @@ impl CompileArgs {
     }
 }
 
-#[derive(Debug)]
-/// Handles a series of errors
-struct ProcessErrs(Vec<String>);
-
-impl Display for ProcessErrs {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        for s in &self.0 {
-            f.write_str(&format!("{s}\n"))?;
-        }
-        Ok(())
-    }
-}
-
-impl From<String> for ProcessErrs {
-    fn from(value: String) -> Self {
-        Self(vec![value])
-    }
-}
-
-impl From<LLVMString> for ProcessErrs {
-    fn from(value: LLVMString) -> Self {
-        Self(vec![value.to_string()])
-    }
-}
-
-impl From<&str> for ProcessErrs {
-    fn from(value: &str) -> Self {
-        Self(vec![value.to_string()])
-    }
-}
-
-impl From<Vec<String>> for ProcessErrs {
-    fn from(value: Vec<String>) -> Self {
-        Self(value)
-    }
-}
 
 impl Error for ProcessErrs {}
 

--- a/src/target.rs
+++ b/src/target.rs
@@ -29,6 +29,7 @@ impl CompileTarget {
         }
     }
     pub fn machine(self, level: OptimizationLevel) -> TargetMachine {
+        self.initialise();
         let reloc_mode = RelocMode::PIC;
         let code_model = CodeModel::Default;
         match self {
@@ -46,7 +47,7 @@ impl CompileTarget {
             Self::QuantinuumHardware => {
                 // aarch64-unknown-linux-gnu
                 // arm64-unknown-none
-                let triple = TargetTriple::create("arm64-unknown-none");
+                let triple = TargetTriple::create("aarch64-unknown-linux-gnu");
                 Target::from_triple(&triple)
                     .unwrap()
                     .create_target_machine(&triple, "", "", level, reloc_mode, code_model)

--- a/src/target.rs
+++ b/src/target.rs
@@ -1,0 +1,57 @@
+use crate::inkwell::{
+    OptimizationLevel,
+    targets::{CodeModel, InitializationConfig, RelocMode, Target, TargetMachine, TargetTriple},
+};
+
+// use inkwell::targets::{InitializationConfig, Target, TargetMachine};
+
+#[derive(Clone, Debug, Copy, Default)]
+#[non_exhaustive]
+pub enum CompileTarget {
+    #[default]
+    QuantinuumHardware,
+    Native,
+}
+
+impl CompileTarget {
+    pub fn initialise(&self) {
+        match self {
+            Self::Native => {
+                let _ = Target::initialize_native(&Default::default());
+            }
+            Self::QuantinuumHardware => {
+                // Target::initialize_aarch64(&Default::default());
+                // Target::initialize_aarch64();
+                let _ = Target::initialize_all(&InitializationConfig::default());
+                // initialize_x86
+                // initialize_all
+            }
+        }
+    }
+    pub fn machine(self, level: OptimizationLevel) -> TargetMachine {
+        let reloc_mode = RelocMode::PIC;
+        let code_model = CodeModel::Default;
+        match self {
+            Self::Native => Target::from_triple(&TargetMachine::get_default_triple())
+                .unwrap()
+                .create_target_machine(
+                    &TargetMachine::get_default_triple(),
+                    "",
+                    "",
+                    level,
+                    reloc_mode,
+                    code_model,
+                )
+                .unwrap(),
+            Self::QuantinuumHardware => {
+                // aarch64-unknown-linux-gnu
+                // arm64-unknown-none
+                let triple = TargetTriple::create("arm64-unknown-none");
+                Target::from_triple(&triple)
+                    .unwrap()
+                    .create_target_machine(&triple, "", "", level, reloc_mode, code_model)
+                    .unwrap()
+            }
+        }
+    }
+}

--- a/src/target.rs
+++ b/src/target.rs
@@ -3,8 +3,6 @@ use crate::inkwell::{
     targets::{CodeModel, InitializationConfig, RelocMode, Target, TargetMachine, TargetTriple},
 };
 
-// use inkwell::targets::{InitializationConfig, Target, TargetMachine};
-
 #[derive(Clone, Debug, Copy, Default)]
 #[non_exhaustive]
 pub enum CompileTarget {
@@ -20,16 +18,11 @@ impl CompileTarget {
                 let _ = Target::initialize_native(&InitializationConfig::default());
             }
             Self::QuantinuumHardware => {
-                // Target::initialize_aarch64(&Default::default());
-                //Target::initialize_aarch64();
                 Target::initialize_all(&InitializationConfig::default());
-                // initialize_x86
-                // initialize_all
             }
         }
     }
     pub fn machine(self, level: OptimizationLevel) -> TargetMachine {
-        self.initialise();
         let reloc_mode = RelocMode::PIC;
         let code_model = CodeModel::Default;
         match self {
@@ -45,8 +38,6 @@ impl CompileTarget {
                 )
                 .unwrap(),
             Self::QuantinuumHardware => {
-                // aarch64-unknown-linux-gnu
-                // arm64-unknown-none
                 let triple = TargetTriple::create("aarch64-unknown-linux-gnu");
                 Target::from_triple(&triple)
                     .unwrap()

--- a/src/target.rs
+++ b/src/target.rs
@@ -17,12 +17,12 @@ impl CompileTarget {
     pub fn initialise(&self) {
         match self {
             Self::Native => {
-                let _ = Target::initialize_native(&Default::default());
+                let _ = Target::initialize_native(&InitializationConfig::default());
             }
             Self::QuantinuumHardware => {
                 // Target::initialize_aarch64(&Default::default());
-                // Target::initialize_aarch64();
-                let _ = Target::initialize_all(&InitializationConfig::default());
+                //Target::initialize_aarch64();
+                Target::initialize_all(&InitializationConfig::default());
                 // initialize_x86
                 // initialize_all
             }

--- a/uv.lock
+++ b/uv.lock
@@ -612,7 +612,7 @@ wheels = [
 
 [[package]]
 name = "hugr-qir"
-version = "0.0.6"
+version = "0.0.7"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Use the llvm specific default optimization for the device.

Solves:
https://github.com/CQCL/hugr-qir/issues/74
https://github.com/CQCL/hugr-qir/issues/72
https://github.com/CQCL/hugr-qir/issues/53
https://github.com/CQCL/hugr-qir/issues/46
https://github.com/CQCL/hugr-qir/issues/34


The generated QIR looks a little bit different, the quantinuum-qir check is happy with this, and the submission to H1-1SC still works, too.
