### PR TITLE
Run tests after building wheels

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.23.2
+        uses: pypa/cibuildwheel@v3.1.2
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -33,6 +33,7 @@ jobs:
       matrix:
         # macos-13 is an intel runner, macos-14 is apple silicon
         os: [ubuntu-latest, macos-13, macos-14, windows-latest]
+      fail-fast: false
 
     steps:
       - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,3 +102,8 @@ repair-wheel-command = [
     'delvewheel repair -w {dest_dir} {wheel}',
     'pipx run abi3audit --strict --report {wheel}',
 ]
+test-groups = []
+before-test = [
+    'pip install --upgrade pip',
+    'pip install --group {project}/pyproject.toml:dev'
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ reportMissingModuleSource = "none"
 [tool.cibuildwheel]
 build = "cp310-*"
 skip = "*-win32 *-manylinux_i686 *-musllinux*"
-manylinux-x86_64-image = "manylinux_2_28"
+manylinux-x86_64-image = "manylinux_2_34"
 test-groups = ["dev"]
 test-sources = ["python/tests", "guppy_examples"]
 test-command = "pytest python/tests"
@@ -61,7 +61,7 @@ LLVM_SYS_140_PREFIX = '/tmp/llvm'
 before-all = [
     'curl -sSf https://sh.rustup.rs | sh -s -- -y',
     # NOTE: used to be 'dnf install libffi-devel -y',
-    'dnf install https://azure.repo.almalinux.org/8.10/BaseOS/x86_64/os/Packages/libffi-devel-3.1-24.el8.x86_64.rpm -y',
+    'dnf install https://azure.repo.almalinux.org/9.6/BaseOS/x86_64/os/Packages/libffi-3.4.2-8.el9.x86_64.rpm',
     'curl -LO https://github.com/llvm/llvm-project/releases/download/llvmorg-14.0.6/clang+llvm-14.0.6-x86_64-linux-gnu-rhel-8.4.tar.xz',
     'mkdir -p /tmp/llvm',
     'tar xf clang+llvm-14.0.6-x86_64-linux-gnu-rhel-8.4.tar.xz -C /tmp/llvm --strip-components=1',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ build = "cp310-*"
 skip = "*-win32 *-manylinux_i686 *-musllinux*"
 manylinux-x86_64-image = "manylinux_2_28"
 test-groups = ["dev"]
-test-sources = ["python/tests"]
+test-sources = ["python/tests", "guppy_examples"]
 test-command = "pytest python/tests"
 
 [tool.cibuildwheel.linux.environment]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,9 @@ reportMissingModuleSource = "none"
 build = "cp310-*"
 skip = "*-win32 *-manylinux_i686 *-musllinux*"
 manylinux-x86_64-image = "manylinux_2_28"
+test-groups = ["dev"]
+test-sources = ["python/tests"]
+test-command = "pytest python/tests"
 
 [tool.cibuildwheel.linux.environment]
 PATH = '$HOME/.cargo/bin:/tmp/llvm/bin:$PATH'

--- a/python/hugr_qir/cli.py
+++ b/python/hugr_qir/cli.py
@@ -53,12 +53,12 @@ def hugr_qir_impl(
     options = ["-q"]
     if validate_hugr:
         options.append("--validate")
-    with tempfile.NamedTemporaryFile(
-        delete=True, delete_on_close=False, suffix=".ll"
-    ) as temp_file:
-        tmp_options = [*options, "-o", temp_file.name]
+    with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp_dir:
+        tmp_outfile_name = f"{tmp_dir}/tmp.ll"  # noqa: S108
+        tmp_outfile_path = Path(tmp_outfile_name)
+        tmp_options = [*options, "-o", tmp_outfile_name]
         cli(str(hugr_file), *tmp_options)
-        with Path.open(Path(temp_file.name)) as output:
+        with Path.open(tmp_outfile_path) as output:
             qir = output.read()
     if validate_qir:
         try:

--- a/python/hugr_qir/cli.py
+++ b/python/hugr_qir/cli.py
@@ -58,7 +58,6 @@ def hugr_qir_impl(
         cli(str(hugr_file), *tmp_options)
         with Path.open(Path(temp_file.name)) as output:
             qir = output.read()
-        Path(temp_file.name).unlink()
     if validate_qir:
         try:
             qircheck(qir)

--- a/python/hugr_qir/cli.py
+++ b/python/hugr_qir/cli.py
@@ -53,7 +53,7 @@ def hugr_qir_impl(
     options = ["-q"]
     if validate_hugr:
         options.append("--validate")
-    with tempfile.NamedTemporaryFile(delete=True, suffix=".ll") as temp_file:
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".ll") as temp_file:
         tmp_options = [*options, "-o", temp_file.name]
         cli(str(hugr_file), *tmp_options)
         with Path.open(Path(temp_file.name)) as output:

--- a/python/hugr_qir/cli.py
+++ b/python/hugr_qir/cli.py
@@ -58,6 +58,7 @@ def hugr_qir_impl(
         cli(str(hugr_file), *tmp_options)
         with Path.open(Path(temp_file.name)) as output:
             qir = output.read()
+        Path(temp_file.name).unlink()
     if validate_qir:
         try:
             qircheck(qir)

--- a/python/hugr_qir/cli.py
+++ b/python/hugr_qir/cli.py
@@ -53,7 +53,9 @@ def hugr_qir_impl(
     options = ["-q"]
     if validate_hugr:
         options.append("--validate")
-    with tempfile.NamedTemporaryFile(delete=False, suffix=".ll") as temp_file:
+    with tempfile.NamedTemporaryFile(
+        delete=True, delete_on_close=False, suffix=".ll"
+    ) as temp_file:
         tmp_options = [*options, "-o", temp_file.name]
         cli(str(hugr_file), *tmp_options)
         with Path.open(Path(temp_file.name)) as output:

--- a/python/hugr_qir/hugr_to_qir.py
+++ b/python/hugr_qir/hugr_to_qir.py
@@ -31,8 +31,8 @@ def hugr_to_qir(
     passing `as_bitcode = False`)
     """
     with (
-        tempfile.NamedTemporaryFile(delete=True, suffix=".hugr") as temp_infile,
-        tempfile.NamedTemporaryFile(delete=True, suffix=".ll") as temp_outfile,
+        tempfile.NamedTemporaryFile(delete=False, suffix=".hugr") as temp_infile,
+        tempfile.NamedTemporaryFile(delete=False, suffix=".ll") as temp_outfile,
     ):
         hugr_bytes: bytes
 

--- a/python/hugr_qir/hugr_to_qir.py
+++ b/python/hugr_qir/hugr_to_qir.py
@@ -50,9 +50,14 @@ def hugr_to_qir(
             )
         with Path.open(Path(temp_outfile.name), "r") as cli_output:
             qir_ir = cli_output.read()
-            if emit_text:
-                return qir_ir
-            ctx = create_context()
-            module = parse_assembly(qir_ir, context=ctx)
-            qir_bitcode = module.as_bitcode()
-            return b64encode(qir_bitcode).decode("utf-8")
+
+        Path(temp_infile.name).unlink()
+        Path(temp_outfile.name).unlink()
+
+        if emit_text:
+            return qir_ir
+
+        ctx = create_context()
+        module = parse_assembly(qir_ir, context=ctx)
+        qir_bitcode = module.as_bitcode()
+        return b64encode(qir_bitcode).decode("utf-8")

--- a/python/hugr_qir/hugr_to_qir.py
+++ b/python/hugr_qir/hugr_to_qir.py
@@ -31,8 +31,12 @@ def hugr_to_qir(
     passing `as_bitcode = False`)
     """
     with (
-        tempfile.NamedTemporaryFile(delete=False, suffix=".hugr") as temp_infile,
-        tempfile.NamedTemporaryFile(delete=False, suffix=".ll") as temp_outfile,
+        tempfile.NamedTemporaryFile(
+            delete=True, delete_on_close=False, suffix=".hugr"
+        ) as temp_infile,
+        tempfile.NamedTemporaryFile(
+            delete=True, delete_on_close=True, suffix=".ll"
+        ) as temp_outfile,
     ):
         hugr_bytes: bytes
 
@@ -50,9 +54,6 @@ def hugr_to_qir(
             )
         with Path.open(Path(temp_outfile.name), "r") as cli_output:
             qir_ir = cli_output.read()
-
-        Path(temp_infile.name).unlink()
-        Path(temp_outfile.name).unlink()
 
         if emit_text:
             return qir_ir

--- a/python/hugr_qir/hugr_to_qir.py
+++ b/python/hugr_qir/hugr_to_qir.py
@@ -30,15 +30,10 @@ def hugr_to_qir(
     encoded (default) or as human-readable LLVM assembly language (when
     passing `as_bitcode = False`)
     """
-    with (
-        tempfile.NamedTemporaryFile(
-            delete=True, delete_on_close=False, suffix=".hugr"
-        ) as temp_infile,
-        tempfile.NamedTemporaryFile(
-            delete=True, delete_on_close=True, suffix=".ll"
-        ) as temp_outfile,
-    ):
+    with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp_dir:
         hugr_bytes: bytes
+        tmp_infile_path = Path(f"{tmp_dir}/tmp.hugr")  # noqa: S108
+        tmp_outfile_path = Path(f"{tmp_dir}/tmp.ll")  # noqa: S108
 
         if type(hugr) is bytes:
             hugr_bytes = hugr
@@ -46,13 +41,11 @@ def hugr_to_qir(
             assert type(hugr) is ModulePointer  # noqa: S101
             hugr_bytes = hugr.package.to_bytes()
 
-        with Path.open(Path(temp_infile.name), "wb") as cli_input:
+        with Path.open(tmp_infile_path, "wb") as cli_input:
             cli_input.write(hugr_bytes)
-        with Path.open(Path(temp_outfile.name), "w") as cli_output:
-            hugr_qir_impl(
-                validate_qir, validate_hugr, Path(temp_infile.name), cli_output
-            )
-        with Path.open(Path(temp_outfile.name), "r") as cli_output:
+        with Path.open(tmp_outfile_path, "w") as cli_output:
+            hugr_qir_impl(validate_qir, validate_hugr, tmp_infile_path, cli_output)
+        with Path.open(tmp_outfile_path, "r") as cli_output:
             qir_ir = cli_output.read()
 
         if emit_text:

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -20,7 +20,7 @@ def guppy_to_hugr_file(guppy_file: Path, outfd: IO) -> None:
 
 
 def guppy_to_hugr_binary(guppy_file: Path) -> bytes:
-    with tempfile.NamedTemporaryFile(delete=True, suffix=".hugr") as temp_hugrfile:
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".hugr") as temp_hugrfile:
         with Path.open(Path(temp_hugrfile.name), "wb") as outfd:
             subprocess.run(  # noqa: S603
                 [sys.executable, guppy_file],

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -20,17 +20,16 @@ def guppy_to_hugr_file(guppy_file: Path, outfd: IO) -> None:
 
 
 def guppy_to_hugr_binary(guppy_file: Path) -> bytes:
-    with tempfile.NamedTemporaryFile(
-        delete=True, delete_on_close=False, suffix=".hugr"
-    ) as temp_hugrfile:
-        with Path.open(Path(temp_hugrfile.name), "wb") as outfd:
+    with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as temp_dir:
+        temp_hugr_path = Path(f"{temp_dir}/tmp.hugr")  # noqa: S108
+        with Path.open(temp_hugr_path, "wb") as outfd:
             subprocess.run(  # noqa: S603
                 [sys.executable, guppy_file],
                 check=True,
                 stdout=outfd,
                 text=True,
             )
-        with Path.open(Path(temp_hugrfile.name), "rb") as outfd:
+        with Path.open(Path(temp_hugr_path), "rb") as outfd:
             return outfd.read()
 
 

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -20,7 +20,9 @@ def guppy_to_hugr_file(guppy_file: Path, outfd: IO) -> None:
 
 
 def guppy_to_hugr_binary(guppy_file: Path) -> bytes:
-    with tempfile.NamedTemporaryFile(delete=False, suffix=".hugr") as temp_hugrfile:
+    with tempfile.NamedTemporaryFile(
+        delete=True, delete_on_close=False, suffix=".hugr"
+    ) as temp_hugrfile:
         with Path.open(Path(temp_hugrfile.name), "wb") as outfd:
             subprocess.run(  # noqa: S603
                 [sys.executable, guppy_file],
@@ -29,9 +31,7 @@ def guppy_to_hugr_binary(guppy_file: Path) -> bytes:
                 text=True,
             )
         with Path.open(Path(temp_hugrfile.name), "rb") as outfd:
-            result = outfd.read()
-        Path(temp_hugrfile.name).unlink()
-        return result
+            return outfd.read()
 
 
 def get_guppy_files() -> list[Path]:

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -29,7 +29,9 @@ def guppy_to_hugr_binary(guppy_file: Path) -> bytes:
                 text=True,
             )
         with Path.open(Path(temp_hugrfile.name), "rb") as outfd:
-            return outfd.read()
+            result = outfd.read()
+        Path(temp_hugrfile.name).unlink()
+        return result
 
 
 def get_guppy_files() -> list[Path]:


### PR DESCRIPTION
- Now running tests through `cibuildwheel` after wheel builds
- To support the newest versions of pyqir, needed to update the manylinux build container to version 2_34 (Based on almalinux 9 instead of 8).
- `test-groups` option doesn't work on Windows, so using workaround with `before-test` commands to install the `dev` dependency group before running tests
- Windows file permissions are weird and this was causing the implementation with `tempfile.NamedTemporaryFile` to fail. A new implementation using `tempfile.TemporayDirectory` fixes the issue.