### PR TITLE
Reintroduce wheel tests

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - '*'
+  merge_group:
+    types: [ checks_requested ]
   release:
     types:
       - published

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,9 @@ reportMissingModuleSource = "none"
 build = "cp310-*"
 skip = "*-win32 *-manylinux_i686 *-musllinux*"
 manylinux-x86_64-image = "manylinux_2_34"
+test-groups = ["dev"]
+test-sources = ["python/tests", "guppy_examples"]
+test-command = "pytest python/tests"
 
 [tool.cibuildwheel.linux.environment]
 PATH = '$HOME/.cargo/bin:/tmp/llvm/bin:$PATH'
@@ -98,4 +101,8 @@ before-build = ['pip install delvewheel']
 repair-wheel-command = [
     'delvewheel repair -w {dest_dir} {wheel}',
     'pipx run abi3audit --strict --report {wheel}',
+]
+test-groups = []
+before-test = [
+    'pip install --group {project}/pyproject.toml:dev'
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ skip = "*-win32 *-manylinux_i686 *-musllinux*"
 manylinux-x86_64-image = "manylinux_2_34"
 test-groups = ["dev"]
 test-sources = ["python/tests", "guppy_examples"]
-test-command = "pytest python/tests"
+test-command = "pytest python/tests -k test_guppy_files"
 
 [tool.cibuildwheel.linux.environment]
 PATH = '$HOME/.cargo/bin:/tmp/llvm/bin:$PATH'


### PR DESCRIPTION
- Fixed problem with Windows wheel testing (removed unnecessary pip update)
- Now only running tests that compile all guppy examples and qircheck generated llvm (through cli and hugr_to_qir function)
   - The snapshot tests fail due to seemingly random different name of a variable label
- The builds/tests now also run on PRs so we catch any problems sooner

Fixes #61 