### PR TITLE
docs: simplify docs build

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,6 +8,14 @@ on:
   push:
     branches:
       - 'docs/*'
+  release:
+    types:
+      - published
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
 
 jobs:
   docs-checks:
@@ -40,3 +48,13 @@ jobs:
         with:
           name: docs
           path: docs/_build/html/
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/_build/html/
+      - name: Deploy to GitHub Pages
+        if: github.event_name == 'release'
+        id: deployment
+        uses: actions/deploy-pages@v5

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "docs/pytket-docs-theming"]
-	path = docs/pytket-docs-theming
-	url = https://github.com/Quantinuum/pytket-docs-theming.git
-	branch = main

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Changelog
 
+### v0.0.28rc0
+
+- add documentation
+- update hugr python version to >= 0.15.4
+- update guppylang version to ~= 0.21.11
+
 ### v0.0.27
 
 - don't generate qir basic blocks with purely numerical names

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1008,7 +1008,7 @@ dependencies = [
 
 [[package]]
 name = "hugr-qir"
-version = "0.0.28"
+version = "0.0.28-rc.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hugr-qir"
-version = "0.0.28"
+version = "0.0.28-rc.0"
 edition = "2024"
 rust-version = "1.89"
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A tool for converting Hierarchical Unified Graph Representation (HUGR, pronounce
 
 ## Documentation
 
-Project documentation lives in [docs/](docs/) and is organized as a small Sphinx site using the shared `pytket-docs-theming` configuration.
+Project documentation lives in [docs/](docs/) and can be viewed online [here](https://quantinuum.github.io/hugr-qir/).
 
 - Getting started: [docs/getting-started.md](docs/getting-started.md)
 - Examples: [docs/examples/index.md](docs/examples/index.md)

--- a/docs/__init__.py
+++ b/docs/__init__.py
@@ -1,1 +1,0 @@
-# Documentation package marker for local tooling.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,31 +1,9 @@
 # Python CLI
 
-Detailed information on options and option defaults can be generated using `hugr-qir -h/--help`.
+The `hugr-qir` command line tool reads a HUGR package and emits QIR. Run `hugr-qir -h/--help` for more information.
 
-The CLI outputs QIR to stdout by default but can be configured to write to a file and to output in various formats.
-
-## Basic usage
-
-```bash
-hugr-qir input.hugr
-```
-
-This reads a HUGR package and emits QIR.
-
-## Common options
-
-- `-h, --help`: print help message including all options/defaults
-- `-o, --output`: write to a file instead of stdout
-- `-f, --output-format`: choose `llvm-ir` for readable LLVM IR, `bitcode` for LLVM bitcode, or `base64` for base64-encoded bitcode
-- `-t, --target`: select the compilation target
-- `-l, --opt-level`: choose the LLVM optimization level
-- `--wasm-file`: provide a Wasm module for the Wasm extension
-
-Example:
-
-```bash
-hugr-qir program.hugr \
-  --output result.ll \
-  --output-format llvm-ir \
-  --opt-level aggressive
+```{eval-rst}
+.. click:: hugr_qir.cli:hugr_qir
+   :prog: hugr-qir
+   :nested: full
 ```

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,4 +1,4 @@
-# Configuration file for the Sphinx documentation builder.
+# Configuration file for the Sphinx documentation builder.  # noqa: INP001
 #
 # For the full list of built-in configuration values, see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
@@ -15,7 +15,7 @@ from importlib.metadata import version as check_version
 
 
 project = f"hugr-qir v{check_version('hugr-qir')}"
-copyright = "2026, Quantinuum"
+copyright = "2026, Quantinuum"  # noqa: A001
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,6 +26,7 @@ extensions = [
     "sphinx_copybutton",
     "myst_parser",
     "sphinx_autodoc_typehints",
+    "sphinx_click",
 ]
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -7,7 +7,14 @@
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
 
-project = "hugr-qir"
+# Alias needed here to prevent naming clash with something else sphinx is doing.
+from importlib.metadata import version as check_version
+
+# Checking the version used in the Python environment means that pyproject.toml
+#  serves as the single source of truth for the version of hugr-qir.
+
+
+project = f"hugr-qir v{check_version('hugr-qir')}"
 copyright = "2026, Quantinuum"
 
 # -- General configuration ---------------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,38 +1,35 @@
-import runpy
-from pathlib import Path
+# Configuration file for the Sphinx documentation builder.
+#
+# For the full list of built-in configuration values, see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
 
-DOCS_DIR = Path(__file__).resolve().parent
-THEMING_DIR = DOCS_DIR / "pytket-docs-theming"
+# -- Project information -----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
-# Load the shared Quantinuum/pytket docs configuration first, then override the
-# project-specific pieces that should remain local to hugr-qir.
-_shared_conf = runpy.run_path(str(THEMING_DIR / "conf.py"))
-globals().update(_shared_conf)
 
 project = "hugr-qir"
-copyright = "2026 Quantinuum"  # noqa: A001
-author = "Quantinuum"
-root_doc = "index"
-html_title = "hugr-qir"
+copyright = "2026, Quantinuum"
 
-# Our docs are Markdown-based and live directly under docs/.
-source_suffix = {
-    ".md": "myst-nb",
-}
+# -- General configuration ---------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
-templates_path = ["_templates"]
-html_static_path = ["pytket-docs-theming/_static"]
-html_favicon = "pytket-docs-theming/_static/assets/quantinuum_favicon.svg"
-
-# Exclude the theming submodule itself from the documentation source tree.
-exclude_patterns = [
-    *_shared_conf.get("exclude_patterns", []),
-    "pytket-docs-theming",
-    "pytket-docs-theming/**",
+extensions = [
+    "sphinx.ext.autosummary",
+    "sphinx.ext.viewcode",
+    "sphinx_copybutton",
+    "myst_parser",
+    "sphinx_autodoc_typehints",
 ]
 
-# This repository does not build API docs via autodoc yet and does not ship
-# notebooks, so keep notebook execution disabled and avoid repo-name-based
-# coverage configuration from the shared config.
-nb_execution_mode = "off"
-coverage_modules: list[str] = []
+
+# -- Options for HTML output -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+
+html_theme = "furo"
+
+
+intersphinx_mapping = {
+    "python": ("https://docs.python.org/3", None),
+    "pytket": ("https://docs.quantinuum.com/tket/api-docs/", None),
+    "hugr": ("https://quantinuum.github.io/hugr/", None),
+}

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -54,3 +54,11 @@ bitcode = hugr_to_qir(hugr_package, output_format=OutputFormat.BITCODE)
 ## Error behavior
 
 The Python wrapper raises `ValueError` when code generation or validation fails. For Wasm-related failures, the backend attempts to produce function-specific errors that mention the Wasm function being looked up.
+
+
+# hugr-qir
+
+```{eval-rst}
+.. currentmodule:: hugr_qir.hugr_to_qir
+.. autofunction:: hugr_to_qir
+```

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -4,19 +4,21 @@
 
 The Python layer centers on `python/hugr_qir/hugr_to_qir.py`.
 
+
 ### `hugr_to_qir`
 
+```{eval-rst}
+.. currentmodule:: hugr_qir.hugr_to_qir
+.. autofunction:: hugr_to_qir
+```
+
+Example:
+
 ```python
-hugr_to_qir(
-    hugr,
-    *,
-    validate_qir=True,
-    validate_hugr=False,
-    target="quantinuum-hardware",
-    opt_level="aggressive",
-    output_format=OutputFormat.BASE64,
-    wasm_file=None,
-)
+from hugr_qir.hugr_to_qir import hugr_to_qir
+from hugr_qir.output import OutputFormat
+
+bitcode = hugr_to_qir(hugr_package, output_format=OutputFormat.BITCODE)
 ```
 
 Key parameters:
@@ -29,36 +31,19 @@ Key parameters:
 - `output_format`: `LLVM_IR`, `BITCODE`, or `BASE64`
 - `wasm_file`: optional path to a Wasm module used by the Wasm extension
 
+
 ### Convenience helpers
 
-- `to_qir_str(...)`: returns LLVM IR as `str`
-- `to_qir_bytes(...)`: returns bitcode as `bytes`
+```{eval-rst}
+.. currentmodule:: hugr_qir.hugr_to_qir
+.. autofunction:: to_qir_str
+.. autofunction:: to_qir_bytes
+```
 
 ## Output formats
 
-The output enum lives in `python/hugr_qir/output.py`.
+The output format enum lives in `python/hugr_qir/output.py`.
 
 - `OutputFormat.LLVM_IR`
 - `OutputFormat.BITCODE`
 - `OutputFormat.BASE64`
-
-Example:
-
-```python
-from hugr_qir.hugr_to_qir import hugr_to_qir
-from hugr_qir.output import OutputFormat
-
-bitcode = hugr_to_qir(hugr_package, output_format=OutputFormat.BITCODE)
-```
-
-## Error behavior
-
-The Python wrapper raises `ValueError` when code generation or validation fails. For Wasm-related failures, the backend attempts to produce function-specific errors that mention the Wasm function being looked up.
-
-
-# hugr-qir
-
-```{eval-rst}
-.. currentmodule:: hugr_qir.hugr_to_qir
-.. autofunction:: hugr_to_qir
-```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ docs = [
     "sphinx-autodoc-typehints<3.2",
     "sphinx-copybutton>=0.5.2,<1",
     "sphinxcontrib-googleanalytics>=0.5",
+    "sphinx-click>=6.2.0"
 ]
 examples = [
     "jupyterlab>=4.5.3",

--- a/python/hugr_qir/cli.py
+++ b/python/hugr_qir/cli.py
@@ -29,12 +29,14 @@ CONTEXT_SETTINGS = {"help_option_names": ["-h", "--help"]}
     "--validate-qir/--no-validate-qir",
     "validate_qir",
     default=True,
+    show_default=True,
     help="Whether to validate the QIR output",
 )
 @click.option(
     "--validate-hugr/--no-validate-hugr",
     "validate_hugr",
     default=False,
+    show_default=True,
     help="Whether to validate the input hugr before and after each internal pass",
 )
 @click.option(

--- a/python/hugr_qir/hugr_to_qir.py
+++ b/python/hugr_qir/hugr_to_qir.py
@@ -69,6 +69,8 @@ def to_qir_str(hugr: Package | bytes, *, validate_qir: bool = True) -> str:
     """
     Converts hugr package to qir str
 
+    Uses hugr_to_qir internally with default settings and llvm_ir output format.
+
     :param hugr: hugr package
     :type hugr: Package
     :param validate_qir: Whether to validate the created QIR
@@ -86,7 +88,9 @@ def to_qir_str(hugr: Package | bytes, *, validate_qir: bool = True) -> str:
 
 def to_qir_bytes(hugr: Package | bytes, *, validate_qir: bool = True) -> bytes:
     """
-    Converts hugr package to qir bytes
+    Converts hugr package to qir bytes.
+
+    Uses hugr_to_qir internally with default settings and bitcode output format.
 
     :param hugr: hugr package
     :type hugr: Package

--- a/python/tests/test_compile_qir.py
+++ b/python/tests/test_compile_qir.py
@@ -1,5 +1,4 @@
 import re
-from importlib.metadata import version
 from typing import no_type_check
 
 import pytest
@@ -46,7 +45,7 @@ def test_generated_qir_uses_qir_1_runtime_contracts(
     # remove version override for this test only
     monkeypatch.delenv("HUGR_QIR_VERSION_TEST_OVERRIDE", raising=False)
     qir = guppy_to_qir_str(main, validate_qir=True)
-    package_version = version("hugr-qir")
+    package_version = "0.0.28-rc.0" # not working for RC version: version("hugr-qir")
 
     assert "__quantum__rt__read_result" in qir
     assert "__quantum__qis__read_result__body" not in qir
@@ -59,6 +58,7 @@ def test_generated_qir_uses_qir_1_runtime_contracts(
         gen_name_pattern,
         qir,
     )
+
     gen_version_pattern = (
         rf"@gen_version = private unnamed_addr constant "
         rf'\[{len(package_version)} x i8\] c"{re.escape(package_version)}", '

--- a/python/tests/test_compile_qir.py
+++ b/python/tests/test_compile_qir.py
@@ -45,7 +45,7 @@ def test_generated_qir_uses_qir_1_runtime_contracts(
     # remove version override for this test only
     monkeypatch.delenv("HUGR_QIR_VERSION_TEST_OVERRIDE", raising=False)
     qir = guppy_to_qir_str(main, validate_qir=True)
-    package_version = "0.0.28-rc.0" # not working for RC version: version("hugr-qir")
+    package_version = "0.0.28-rc.0"  # not working for RC version: version("hugr-qir")
 
     assert "__quantum__rt__read_result" in qir
     assert "__quantum__qis__read_result__body" not in qir

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.15' and platform_machine == 'x86_64' and sys_platform == 'darwin'",
@@ -779,14 +779,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/b0/03/84359833f7e1d49a883e92777637c592306030e30cee5e2b1e6476f95c88/greenlet-3.5.0-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:29ea813b2e1f45fa9649a17853b2b5465c4072fbcb072e5af6cd3a288216574a", size = 283502, upload-time = "2026-04-27T12:20:55.213Z" },
     { url = "https://files.pythonhosted.org/packages/25/ce/6f9f008266273aa14a2e011945797ac5802b97b8b40efe7afe1ee6c1afc9/greenlet-3.5.0-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:804a70b328e706b785c6ef16187051c394a63dd1a906d89be24b6ad77759f13f", size = 600508, upload-time = "2026-04-27T12:52:37.876Z" },
     { url = "https://files.pythonhosted.org/packages/e0/6d/b0f3272c2368ea2c1aa19a5ad70db0be8f8dff6e6d3d1eb82efa00cbcf19/greenlet-3.5.0-cp310-cp310-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:884f649de075b84739713d41dd4dfd41e2b910bfb769c4a3ea02ec1da52cd9bb", size = 613283, upload-time = "2026-04-27T12:59:37.957Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/ae/1db979ff6ae7958d80b288f63d5f6c30df96682700ea9fc340ce994d94a1/greenlet-3.5.0-cp310-cp310-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4d0eadc7e4d9ffb2af4247b606cae307be8e448911e5a0d0b16d72fc3d224cfd", size = 619894, upload-time = "2026-04-27T13:02:35.13Z" },
     { url = "https://files.pythonhosted.org/packages/ed/ac/0b509b6fb93551ce5a01612ee1acda7f7dda4bbb66c99aeb2ab403d205dc/greenlet-3.5.0-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4b28037cb07768933c54d81bfe47a85f9f402f57d7d69743b991a713b63954eb", size = 613418, upload-time = "2026-04-27T12:25:23.852Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/94/b0590e3d1978f02419f30502341c40d72f77eb0a2198119fe27df47714ee/greenlet-3.5.0-cp310-cp310-manylinux_2_39_riscv64.whl", hash = "sha256:f8c30c2225f40dd76c50790f0eb3b5c7c18431efb299e2782083e1981feed243", size = 415681, upload-time = "2026-04-27T13:05:11.494Z" },
     { url = "https://files.pythonhosted.org/packages/03/03/2b2b680ec87aaa97998fb5b8d76658d4d3560386864f17efab33ba7c2e24/greenlet-3.5.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:cda05425526240807408156b6960a17a79a0c760b813573b67027823be760977", size = 1572229, upload-time = "2026-04-27T12:53:23.509Z" },
     { url = "https://files.pythonhosted.org/packages/61/e4/42b259e7a19aff1a270a4bd82caf6353109ed6860c9454e18f37162b83ae/greenlet-3.5.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:9c615f869163e14bb1ced20322d8038fb680b08236521ac3f30cd4c1288785a0", size = 1639886, upload-time = "2026-04-27T12:25:22.325Z" },
     { url = "https://files.pythonhosted.org/packages/6f/b4/733ca47b883b67c57f90d3ecb21055c9ec753597d10754ac201644061f9d/greenlet-3.5.0-cp310-cp310-win_amd64.whl", hash = "sha256:ba8f0bdc2fae6ce915dfd0c16d2d00bca7e4247c1eae4416e06430e522137858", size = 237795, upload-time = "2026-04-27T12:21:40.118Z" },
     { url = "https://files.pythonhosted.org/packages/8b/0f/a91f143f356523ff682309732b175765a9bc2836fd7c081c2c67fedc1ad4/greenlet-3.5.0-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:8f1cc966c126639cd152fdaa52624d2655f492faa79e013fea161de3e6dda082", size = 284726, upload-time = "2026-04-27T12:20:51.402Z" },
     { url = "https://files.pythonhosted.org/packages/95/82/800646c7ffc5dbabd75ddd2f6b519bb898c0c9c969e5d0473bfe5d20bcce/greenlet-3.5.0-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:362624e6a8e5bca3b8233e45eef33903a100e9539a2b995c364d595dbc4018b3", size = 604264, upload-time = "2026-04-27T12:52:39.494Z" },
     { url = "https://files.pythonhosted.org/packages/ca/ac/354867c0bba812fc33b15bc55aedafedd0aee3c7dd91dfca22444157dc0c/greenlet-3.5.0-cp311-cp311-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:5ecd83806b0f4c2f53b1018e0005cd82269ea01d42befc0368730028d850ed1c", size = 616099, upload-time = "2026-04-27T12:59:39.623Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/ab/192090c4a5b30df148c22bf4b8895457d739a7c7c5a7b9c41e5dd7f537f2/greenlet-3.5.0-cp311-cp311-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:fa94cb2288681e3a11645958f1871d48ee9211bd2f66628fdace505927d6e564", size = 623976, upload-time = "2026-04-27T13:02:37.363Z" },
     { url = "https://files.pythonhosted.org/packages/ff/b0/815bece7399e01cadb69014219eebd0042339875c59a59b0820a46ece356/greenlet-3.5.0-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0ff251e9a0279522e62f6176412869395a64ddf2b5c5f782ff609a8216a4e662", size = 615198, upload-time = "2026-04-27T12:25:25.928Z" },
+    { url = "https://files.pythonhosted.org/packages/24/11/05eb2b9b188c6df7d68a89c99134d644a7af616a40b9808e8e6ced315d5d/greenlet-3.5.0-cp311-cp311-manylinux_2_39_riscv64.whl", hash = "sha256:64d6ac45f7271f48e45f67c95b54ef73534c52ec041fcda8edf520c6d811f4bc", size = 418379, upload-time = "2026-04-27T13:05:12.755Z" },
     { url = "https://files.pythonhosted.org/packages/10/80/3b2c0a895d6698f6ddb31b07942ebfa982f3e30888bc5546a5b5990de8b2/greenlet-3.5.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:6d874e79afd41a96e11ff4c5d0bc90a80973e476fda1c2c64985667397df432b", size = 1574927, upload-time = "2026-04-27T12:53:25.81Z" },
     { url = "https://files.pythonhosted.org/packages/44/0e/f354af514a4c61454dbc68e44d47544a5a4d6317e30b77ddfa3a09f4c5f3/greenlet-3.5.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:0ed006e4b86c59de7467eb2601cd1b77b5a7d657d1ee55e30fe30d76451edba4", size = 1642683, upload-time = "2026-04-27T12:25:23.9Z" },
     { url = "https://files.pythonhosted.org/packages/fa/6a/87f38255201e993a1915265ebb80cd7c2c78b04a45744995abbf6b259fd8/greenlet-3.5.0-cp311-cp311-win_amd64.whl", hash = "sha256:703cb211b820dbffbbc55a16bfc6e4583a6e6e990f33a119d2cc8b83211119c8", size = 238115, upload-time = "2026-04-27T12:21:48.845Z" },
@@ -794,7 +798,9 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ef/32/f2ce6d4cac3e55bc6173f92dbe627e782e1850f89d986c3606feb63aafa7/greenlet-3.5.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:db2910d3c809444e0a20147361f343fe2798e106af8d9d8506f5305302655a9f", size = 286228, upload-time = "2026-04-27T12:20:34.421Z" },
     { url = "https://files.pythonhosted.org/packages/b7/aa/caed9e5adf742315fc7be2a84196373aab4816e540e38ba0d76cb7584d68/greenlet-3.5.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3ec9ea74e7268ace7f9aab1b1a4e730193fc661b39a993cd91c606c32d4a3628", size = 601775, upload-time = "2026-04-27T12:52:41.045Z" },
     { url = "https://files.pythonhosted.org/packages/c7/af/90ae08497400a941595d12774447f752d3dfe0fbb012e35b76bc5c0ff37e/greenlet-3.5.0-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:54d243512da35485fc7a6bf3c178fdda6327a9d6506fcdd62b1abd1e41b2927b", size = 614436, upload-time = "2026-04-27T12:59:41.595Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/e9/4eeadf8cb3403ac274245ba75f07844abc7fa5f6787583fc9156ba741e0f/greenlet-3.5.0-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:41353ec2ecedf7aa8f682753a41919f8718031a6edac46b8d3dc7ed9e1ceb136", size = 620610, upload-time = "2026-04-27T13:02:39.194Z" },
     { url = "https://files.pythonhosted.org/packages/2b/e0/2e13df68f367e2f9960616927d60857dd7e56aaadd59a47c644216b2f920/greenlet-3.5.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9d280a7f5c331622c69f97eb167f33577ff2d1df282c41cd15907fc0a3ca198c", size = 611388, upload-time = "2026-04-27T12:25:28.008Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/ef/f913b3c0eb7d26d86a2401c5e1546c9d46b657efee724b06f6f4ac5d8824/greenlet-3.5.0-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:58c1c374fe2b3d852f9b6b11a7dff4c85404e51b9a596fd9e89cf904eb09866d", size = 422775, upload-time = "2026-04-27T13:05:14.261Z" },
     { url = "https://files.pythonhosted.org/packages/82/f7/393c64055132ac0d488ef6be549253b7e6274194863967ddc0bc8f5b87b8/greenlet-3.5.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:1eb67d5adefb5bd2e182d42678a328979a209e4e82eb93575708185d31d1f588", size = 1570768, upload-time = "2026-04-27T12:53:28.099Z" },
     { url = "https://files.pythonhosted.org/packages/b8/4b/eaf7735253522cf56d1b74d672a58f54fc114702ceaf05def59aae72f6e1/greenlet-3.5.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2628d6c86f6cb0cb45e0c3c54058bbec559f57eaae699447748cb3928150577e", size = 1635983, upload-time = "2026-04-27T12:25:26.903Z" },
     { url = "https://files.pythonhosted.org/packages/4c/fe/4fb3a0805bd5165da5ebf858da7cc01cce8061674106d2cf5bdab32cbfde/greenlet-3.5.0-cp312-cp312-win_amd64.whl", hash = "sha256:d4d9f0624c775f2dfc56ba54d515a8c771044346852a918b405914f6b19d7fd8", size = 238840, upload-time = "2026-04-27T12:23:54.806Z" },
@@ -802,7 +808,9 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/0c/58/fc576f99037ce19c5aa16628e4c3226b6d1419f72a62c79f5f40576e6eb3/greenlet-3.5.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:5a5ed18de6a0f6cc7087f1563f6bd93fc7df1c19165ca01e9bde5a5dc281d106", size = 285066, upload-time = "2026-04-27T12:23:05.033Z" },
     { url = "https://files.pythonhosted.org/packages/4a/ba/b28ddbe6bfad6a8ac196ef0e8cff37bc65b79735995b9e410923fffeeb70/greenlet-3.5.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a717fbc46d8a354fa675f7c1e813485b6ba3885f9bef0cd56e5ba27d758ff5b", size = 604414, upload-time = "2026-04-27T12:52:42.358Z" },
     { url = "https://files.pythonhosted.org/packages/09/06/4b69f8f0b67603a8be2790e55107a190b376f2627fe0eaf5695d85ffb3cd/greenlet-3.5.0-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ddc090c5c1792b10246a78e8c2163ebbe04cf877f9d785c230a7b27b39ad038e", size = 617349, upload-time = "2026-04-27T12:59:43.32Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/15/a643b4ecd09969e30b8a150d5919960caae0abe4f5af75ab040b1ab85e78/greenlet-3.5.0-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4964101b8585c144cbda5532b1aa644255126c08a265dae90c16e7a0e63aaa9d", size = 623234, upload-time = "2026-04-27T13:02:40.611Z" },
     { url = "https://files.pythonhosted.org/packages/8a/17/a3918541fd0ddefe024a69de6d16aa7b46d36ac19562adaa63c7fa180eff/greenlet-3.5.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2094acd54b272cb6eae8c03dd87b3fa1820a4cef18d6889c378d503500a1dc13", size = 613927, upload-time = "2026-04-27T12:25:30.28Z" },
+    { url = "https://files.pythonhosted.org/packages/77/18/3b13d5ef1275b0ffaf933b05efa21408ac4ca95823c7411d79682e4fdcff/greenlet-3.5.0-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:7022615368890680e67b9965d33f5773aade330d5343bbe25560135aaa849eae", size = 425243, upload-time = "2026-04-27T13:05:15.689Z" },
     { url = "https://files.pythonhosted.org/packages/ee/e1/bd0af6213c7dd33175d8a462d4c1fe1175124ebed4855bc1475a5b5242c2/greenlet-3.5.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5e05ba267789ea87b5a155cf0e810b1ab88bf18e9e8740813945ceb8ee4350ba", size = 1570893, upload-time = "2026-04-27T12:53:29.483Z" },
     { url = "https://files.pythonhosted.org/packages/9b/2a/0789702f864f5382cb476b93d7a9c823c10472658102ccd65f415747d2e2/greenlet-3.5.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:0ecec963079cd58cbd14723582384f11f166fd58883c15dcbfb342e0bc9b5846", size = 1636060, upload-time = "2026-04-27T12:25:28.845Z" },
     { url = "https://files.pythonhosted.org/packages/b2/8f/22bf9df92bbff0eb07842b60f7e63bf7675a9742df628437a9f02d09137f/greenlet-3.5.0-cp313-cp313-win_amd64.whl", hash = "sha256:728d9667d8f2f586644b748dbd9bb67e50d6a9381767d1357714ea6825bb3bf5", size = 238740, upload-time = "2026-04-27T12:24:01.341Z" },
@@ -810,7 +818,9 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/94/5e/a70f31e3e8d961c4ce589c15b28e4225d63704e431a23932a3808cbcc867/greenlet-3.5.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:f35807464c4c58c55f0d31dfa83c541a5615d825c2fe3d2b95360cf7c4e3c0a8", size = 285564, upload-time = "2026-04-27T12:23:08.555Z" },
     { url = "https://files.pythonhosted.org/packages/af/a6/046c0a28e21833e4086918218cfb3d8bed51c075a1b700f20b9d7861c0f4/greenlet-3.5.0-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:55fa7ea52771be44af0de27d8b80c02cd18c2c3cddde6c847ecebdf72418b6a1", size = 651166, upload-time = "2026-04-27T12:52:43.644Z" },
     { url = "https://files.pythonhosted.org/packages/47/f8/4af27f71c5ff32a7fbc516adb46370d9c4ae2bc7bd3dc7d066ac542b4b15/greenlet-3.5.0-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a97e4821aa710603f94de0da25f25096454d78ffdace5dc77f3a006bc01abba3", size = 663792, upload-time = "2026-04-27T12:59:44.93Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/89/2dadb89793c37ee8b4c237857188293e9060dc085f19845c292e00f8e091/greenlet-3.5.0-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:bf2d8a80bec89ab46221ae45c5373d5ba0bd36c19aa8508e85c6cd7e5106cd37", size = 668086, upload-time = "2026-04-27T13:02:42.314Z" },
     { url = "https://files.pythonhosted.org/packages/a3/59/1bd6d7428d6ed9106efbb8c52310c60fd04f6672490f452aeaa3829aa436/greenlet-3.5.0-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8f52a464e4ed91780bdfbbdd2b97197f3accaa629b98c200f4dffada759f3ae7", size = 660933, upload-time = "2026-04-27T12:25:33.276Z" },
+    { url = "https://files.pythonhosted.org/packages/82/35/75722be7e26a2af4cbd2dc35b0ed382dacf9394b7e75551f76ed1abe87f2/greenlet-3.5.0-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:1bae92a1dd94c5f9d9493c3a212dd874c202442047cf96446412c862feca83a2", size = 470799, upload-time = "2026-04-27T13:05:17.094Z" },
     { url = "https://files.pythonhosted.org/packages/83/e4/b903e5a5fae1e8a28cdd32a0cfbfd560b668c25b692f67768822ddc5f40f/greenlet-3.5.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:762612baf1161ccb8437c0161c668a688223cba28e1bf038f4eb47b13e39ccdf", size = 1618401, upload-time = "2026-04-27T12:53:31.062Z" },
     { url = "https://files.pythonhosted.org/packages/0e/e3/5ec408a329acb854fb607a122e1ee5fb3ff649f9a97952948a90803c0d8e/greenlet-3.5.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:57a43c6079a89713522bc4bcb9f75070ecf5d3dbad7792bfe42239362cbf2a16", size = 1682038, upload-time = "2026-04-27T12:25:31.838Z" },
     { url = "https://files.pythonhosted.org/packages/91/20/6b165108058767ee643c55c5c4904d591a830ee2b3c7dbd359828fbc829f/greenlet-3.5.0-cp314-cp314-win_amd64.whl", hash = "sha256:3bc59be3945ae9750b9e7d45067d01ae3fe90ea5f9ade99239dabdd6e28a5033", size = 239835, upload-time = "2026-04-27T12:24:54.136Z" },
@@ -818,7 +828,9 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/78/a8/4522939255bb5409af4e87132f915446bf3622c2c292d14d3c38d128ae82/greenlet-3.5.0-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:a10a732421ab4fec934783ce3e54763470d0181db6e3468f9103a275c3ed1853", size = 293614, upload-time = "2026-04-27T12:24:12.874Z" },
     { url = "https://files.pythonhosted.org/packages/15/5e/8744c52e2c027b5a8772a01561934c8835f869733e101f62075c60430340/greenlet-3.5.0-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7fc391b1566f2907d17aaebe78f8855dc45675159a775fcf9e61f8ee0078e87f", size = 650723, upload-time = "2026-04-27T12:52:45.412Z" },
     { url = "https://files.pythonhosted.org/packages/00/ef/7b4c39c03cf46ceca512c5d3f914afd85aa30b2cc9a93015b0dd73e4be6c/greenlet-3.5.0-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:680bd0e7ad5e8daa8a4aa89f68fd6adc834b8a8036dc256533f7e08f4a4b01f7", size = 656529, upload-time = "2026-04-27T12:59:46.295Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/5c/0602239503b124b70e39355cbdb39361ecfe65b87a5f2f63752c32f5286f/greenlet-3.5.0-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:1aa4ce8debcd4ea7fb2e150f3036588c41493d1d52c43538924ae1819003f4ce", size = 657015, upload-time = "2026-04-27T13:02:43.973Z" },
     { url = "https://files.pythonhosted.org/packages/0b/b5/c7768f352f5c010f92064d0063f987e7dc0cd290a6d92a34109015ce4aa1/greenlet-3.5.0-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ddb36c7d6c9c0a65f18c7258634e0c416c6ab59caac8c987b96f80c2ebda0112", size = 654364, upload-time = "2026-04-27T12:25:35.64Z" },
+    { url = "https://files.pythonhosted.org/packages/38/51/8699f865f125dc952384cb432b0f7138aa4d8f2969a7d12d0df5b94d054d/greenlet-3.5.0-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:728a73687e39ae9ca34e4694cbf2f049d3fbc7174639468d0f67200a97d8f9e2", size = 488275, upload-time = "2026-04-27T13:05:18.28Z" },
     { url = "https://files.pythonhosted.org/packages/ef/d0/079ebe12e4b1fc758857ce5be1a5e73f06870f2101e52611d1e71925ce54/greenlet-3.5.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e5ddf316ced87539144621453c3aef229575825fe60c604e62bedc4003f372b2", size = 1614204, upload-time = "2026-04-27T12:53:32.618Z" },
     { url = "https://files.pythonhosted.org/packages/6d/89/6c2fb63df3596552d20e58fb4d96669243388cf680cff222758812c7bfaa/greenlet-3.5.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:4a448128607be0de65342dc9b31be7f948ef4cc0bc8832069350abefd310a8f2", size = 1675480, upload-time = "2026-04-27T12:25:34.168Z" },
     { url = "https://files.pythonhosted.org/packages/15/32/77ee8a6c1564fc345a491a4e85b3bf360e4cf26eac98c4532d2fdb96e01f/greenlet-3.5.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d60097128cb0a1cab9ea541186ea13cd7b847b8449a7787c2e2350da0cb82d86", size = 245324, upload-time = "2026-04-27T12:24:40.295Z" },
@@ -984,6 +996,7 @@ docs = [
     { name = "sphinx", version = "8.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "sphinx-autodoc-typehints", version = "3.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "sphinx-autodoc-typehints", version = "3.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "sphinx-click" },
     { name = "sphinx-copybutton" },
     { name = "sphinxcontrib-googleanalytics" },
 ]
@@ -1018,6 +1031,7 @@ docs = [
     { name = "quantinuum-sphinx", specifier = "~=0.6" },
     { name = "sphinx", specifier = ">=8,<9" },
     { name = "sphinx-autodoc-typehints", specifier = "<3.2" },
+    { name = "sphinx-click", specifier = ">=6.2.0" },
     { name = "sphinx-copybutton", specifier = ">=0.5.2,<1" },
     { name = "sphinxcontrib-googleanalytics", specifier = ">=0.5" },
 ]
@@ -3668,6 +3682,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/98/0b/a866924ded68efec7a1759587a4e478aec7559d8165fac8b2ad1c0e774d6/sphinx_basic_ng-1.0.0b2.tar.gz", hash = "sha256:9ec55a47c90c8c002b5960c57492ec3021f5193cb26cebc2dc4ea226848651c9", size = 20736, upload-time = "2023-07-08T18:40:54.166Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3c/dd/018ce05c532a22007ac58d4f45232514cd9d6dd0ee1dc374e309db830983/sphinx_basic_ng-1.0.0b2-py3-none-any.whl", hash = "sha256:eb09aedbabfb650607e9b4b68c9d240b90b1e1be221d6ad71d61c52e29f7932b", size = 22496, upload-time = "2023-07-08T18:40:52.659Z" },
+]
+
+[[package]]
+name = "sphinx-click"
+version = "6.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "docutils" },
+    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "sphinx", version = "8.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9a/ed/a9767cd1b8b7fbdf260a89d5c8c86e20e3536b9878579e5ab7965a291e55/sphinx_click-6.2.0.tar.gz", hash = "sha256:fc78b4154a4e5159462e36de55b8643747da6cda86b3b52a8bb62289e603776c", size = 27035, upload-time = "2025-12-04T19:33:05.437Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/44/bd/cb244695f67f77b0a36200ce1670fc42a6fe2770847e870daab99cc2b177/sphinx_click-6.2.0-py3-none-any.whl", hash = "sha256:1fb1851cb4f2c286d43cbcd57f55db6ef5a8d208bfc3370f19adde232e5803d7", size = 8939, upload-time = "2025-12-04T19:33:04.037Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Feel free to push to this branch, just sosme recommedations

Couple of changes

Fixed the navbar. There's just a blank space here. 

<img width="1508" height="331" alt="Screenshot 2026-05-21 at 11 12 32" src="https://github.com/user-attachments/assets/cf165933-ca37-44a4-bcd6-e9a5a8234762" />

This was done by using the base [furo theme](https://github.com/pradyunsg/furo),. The quantinuum-sphinx theme is only intended for use on the docs.quantinuum.com website. You can also get dark mode.


I'm also modified the `python-api.md` file to get the docstrings and function parameters from the source code. I think this is more maintainable

<img width="809" height="504" alt="Screenshot 2026-05-21 at 11 15 57" src="https://github.com/user-attachments/assets/cf0bbb9a-365e-4ddc-b36c-ae4d354ff961" />


I'd recommend playing around with the options for sphinx-autodoc-typehints https://github.com/tox-dev/sphinx-autodoc-typehints you can choose how the type signatures are rendered by sphinx. I'd also recommend removing `rtype:` and `:type` from the docstrings as sphinx can infer the types from the source code directly. 

